### PR TITLE
Fixes

### DIFF
--- a/modules/turnos/routes/carpetaPaciente.ts
+++ b/modules/turnos/routes/carpetaPaciente.ts
@@ -56,10 +56,10 @@ let router = express.Router();
  *           $ref: '#/definitions/carpetaPaciente'
  */
 
-router.get('/carpetasPacientes/:id*?', function(req, res, next) {
+router.get('/carpetasPacientes/:id*?', function (req, res, next) {
 
     if (req.params.id) {
-        carpetaPaciente.findById(req.params.id, function(err, data) {
+        carpetaPaciente.findById(req.params.id, function (err, data) {
             if (err) {
                 return next(err);
             }
@@ -68,30 +68,29 @@ router.get('/carpetasPacientes/:id*?', function(req, res, next) {
     } else {
         let query;
         query = carpetaPaciente.find({});
-        if (req.query.documento) {
-            query.where('documento').equals(req.query.documento);
-        }
-        if (req.query.organizacion) {
-            query.where('carpetaEfectores.organizacion._id').equals(req.query.organizacion);
-        }
+        if (req.query.documento && req.query.organizacion) {
 
-        query.exec((err, data) => {
-            if (err) {
-                return next(err);
-            }
-            if (data && data.length > 0) {
-                let carpetaEfector = data[0].carpetaEfectores.find((carpeta) => {
-                    return (carpeta.organizacion.id === req.query.organizacion);
-                });
-                if (carpetaEfector) {
-                    res.json(carpetaEfector);
+            query.where('documento').equals(req.query.documento);
+            query.where('carpetaEfectores.organizacion._id').equals(req.query.organizacion);
+
+            query.exec((err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                if (data && data.length > 0) {
+                    let carpetaEfector = data[0].carpetaEfectores.find((carpeta) => {
+                        return (carpeta.organizacion.id === req.query.organizacion);
+                    });
+                    if (carpetaEfector) {
+                        res.json(carpetaEfector);
+                    }
+
+                } else {
+                    res.json({});
                 }
 
-            } else {
-                res.json({});
-            }
-
-        });
+            });
+        }
     }
 
 

--- a/utils/validateDarTurno.ts
+++ b/utils/validateDarTurno.ts
@@ -36,11 +36,6 @@ export class ValidateDarTurno {
             errors.push('Paciente no posee ID');
         }
 
-        if (!data.paciente.documento) {
-            valid = false;
-            errors.push('Paciente no tiene especificado el documento');
-        }
-
         return {
             valid: valid,
             errors: errors


### PR DESCRIPTION
- Controlamos que el paciente tenga dni antes de buscar si posee nro de carpeta

- Quitamos el requerimiento de DNI para dar turno