### PR TITLE
fix verificacion de paciente sin documento no guardaba

### DIFF
--- a/core/mpi/routes/paciente.ts
+++ b/core/mpi/routes/paciente.ts
@@ -572,8 +572,6 @@ router.post('/pacientes', function (req, res, next) {
     if (!Auth.check(req, 'mpi:paciente:postAndes')) {
         return next(403);
     }
-    
-    
     if (req.body.documento) {
         let condicion = {
             'documento': req.body.documento
@@ -591,7 +589,6 @@ router.post('/pacientes', function (req, res, next) {
                     return next(error);
                 });
             }
-    
         });
     } else {
         req.body.activo = true;
@@ -599,7 +596,7 @@ router.post('/pacientes', function (req, res, next) {
             return res.json(pacienteObjSinDocumento);
         }).catch((error2 => {
             return next(error2);
-        }))
+        }));
     }
 
 

--- a/core/mpi/routes/paciente.ts
+++ b/core/mpi/routes/paciente.ts
@@ -572,25 +572,37 @@ router.post('/pacientes', function (req, res, next) {
     if (!Auth.check(req, 'mpi:paciente:postAndes')) {
         return next(403);
     }
-    let condicion = {
-        'documento': req.body.documento
-    };
+    
+    
+    if (req.body.documento) {
+        let condicion = {
+            'documento': req.body.documento
+        };
+        controller.searchSimilar(req.body, 'andes', condicion).then((data) => {
+            logD('Encontrados', data.map(item => item.value));
+            if (data && data.length && data[0].value > 0.90) {
+                logD('hay uno parecido');
+                return next('existen similares');
+            } else {
+                req.body.activo = true;
+                return controller.createPaciente(req.body, req).then(pacienteObj => {
+                    return res.json(pacienteObj);
+                }).catch((error) => {
+                    return next(error);
+                });
+            }
+    
+        });
+    } else {
+        req.body.activo = true;
+        return controller.createPaciente(req.body, req).then(pacienteObjSinDocumento => {
+            return res.json(pacienteObjSinDocumento);
+        }).catch((error2 => {
+            return next(error2);
+        }))
+    }
 
-    controller.searchSimilar(req.body, 'andes', condicion).then((data) => {
-        logD('Encontrados', data.map(item => item.value));
-        if (data && data.length && data[0].value > 0.90) {
-            logD('hay uno parecido');
-            return next('existen similares');
-        } else {
-            req.body.activo = true;
-            return controller.createPaciente(req.body, req).then(pacienteObj => {
-                return res.json(pacienteObj);
-            }).catch((error) => {
-                return next(error);
-            });
-        }
 
-    });
 
 });
 


### PR DESCRIPTION
- Verificamos si al hacer el post el paciente tiene documento. Si no tiene debe modificarse el dto y no realizar la validación de match.