### PR TITLE
Fix en clonar

### DIFF
--- a/modules/turnos/routes/agenda.ts
+++ b/modules/turnos/routes/agenda.ts
@@ -288,6 +288,8 @@ router.post('/agenda/clonar', function (req, res, next) {
                             turno.tipoTurno = undefined;
                             turno.updatedAt = undefined;
                             turno.updatedBy = undefined;
+                            turno.diagnosticoPrincipal = null;
+                            turno.diagnosticoSecundario = [];
                         });
                     });
                     nueva['estado'] = 'planificacion';


### PR DESCRIPTION
- Fix: se nullean los diagnosticos principal y secundario cuando clonamos la agenda.