### PR TITLE
Actualizar jobs de cambio de cantidad de turnos

### DIFF
--- a/modules/turnos/controller/agenda.ts
+++ b/modules/turnos/controller/agenda.ts
@@ -489,7 +489,8 @@ export function esPrimerPaciente(agenda: any, idPaciente: string, opciones: any[
  * @returns resultado
  */
 export function actualizarTiposDeTurno() {
-    let hsActualizar = 48;
+    // let hsActualizar = 48;
+    let hsActualizar = 24;
     let cantDias = hsActualizar / 24;
     let fechaActualizar = moment(new Date()).add(cantDias, 'days');
 


### PR DESCRIPTION
Se cambia el parámetro de cantidad de días previos que se realiza la actualización de las agendas