### PR TITLE
normalización del término de búsqueda para cie10

### DIFF
--- a/core/term/routes/cie10.ts
+++ b/core/term/routes/cie10.ts
@@ -38,14 +38,3 @@ router.get('/cie10', function (req, res, next) {
 });
 
 export = router;
-
-
-/* 
-let query;
-query = cie10.model.find({});
-let busqueda = [
-    { 'codigo': RegExp('^.*' + req.query.nombre + '.*$', 'i') },
-    { 'sinonimo': RegExp('^.*' + req.query.nombre + '.*$', 'i') },
-    { 'nombre': RegExp('^.*' + req.query.nombre + '.*$', 'i') },
-];
-query.or(busqueda); */

--- a/core/term/routes/cie10.ts
+++ b/core/term/routes/cie10.ts
@@ -6,7 +6,6 @@ import { defaultLimit, maxLimit } from './../../../config';
 let router = express.Router();
 
 router.get('/cie10', function (req, res, next) {
-    // let filtros = { 'sinonimo': { '$regex': utils.makePattern(req.query.nombre) } };
     let query;
     query = cie10.model.find({});
     let termino: String = '';
@@ -15,7 +14,7 @@ router.get('/cie10', function (req, res, next) {
     words.forEach(function (word) {
         // normalizamos cada una de las palabras como hace SNOMED para poder buscar palabra a palabra
         word = word.replace(/([-()\[\]{}+?*.$\^|,:#<!\\])/g, '\\$1').replace(/\x08/g, '\\x08');
-        let expWord = '^' + utils.removeDiacritics(word) + '.*';
+        let expWord = utils.removeDiacritics(word) + '.*';
         // agregamos la palabra al término de búsqueda
         termino = termino + expWord;
     });
@@ -39,3 +38,14 @@ router.get('/cie10', function (req, res, next) {
 });
 
 export = router;
+
+
+/* 
+let query;
+query = cie10.model.find({});
+let busqueda = [
+    { 'codigo': RegExp('^.*' + req.query.nombre + '.*$', 'i') },
+    { 'sinonimo': RegExp('^.*' + req.query.nombre + '.*$', 'i') },
+    { 'nombre': RegExp('^.*' + req.query.nombre + '.*$', 'i') },
+];
+query.or(busqueda); */

--- a/core/term/routes/cie10.ts
+++ b/core/term/routes/cie10.ts
@@ -9,17 +9,27 @@ router.get('/cie10', function (req, res, next) {
     // let filtros = { 'sinonimo': { '$regex': utils.makePattern(req.query.nombre) } };
     let query;
     query = cie10.model.find({});
+    let termino: String = '';
+    // separamos todas las palabras y eliminamos caracteres extraños
+    let words = String(req.query.nombre).split(' ');
+    words.forEach(function (word) {
+        // normalizamos cada una de las palabras como hace SNOMED para poder buscar palabra a palabra
+        word = word.replace(/([-()\[\]{}+?*.$\^|,:#<!\\])/g, '\\$1').replace(/\x08/g, '\\x08');
+        let expWord = '^' + utils.removeDiacritics(word) + '.*';
+        // agregamos la palabra al término de búsqueda
+        termino = termino + expWord;
+    });
+
     let busqueda = [
-        { 'codigo': RegExp('^.*' + req.query.nombre + '.*$', 'i') },
-        { 'sinonimo': RegExp('^.*' + req.query.nombre + '.*$', 'i') },
-        { 'nombre': RegExp('^.*' + req.query.nombre + '.*$', 'i') },
+        { 'codigo': RegExp('^.*' + termino + '.*$', 'i') },
+        { 'sinonimo': RegExp('^.*' + termino + '.*$', 'i') },
+        { 'nombre': RegExp('^.*' + termino + '.*$', 'i') },
     ];
     query.or(busqueda);
     let skip = parseInt(req.query.skip || 0, 10);
     let limit = Math.min(parseInt(req.query.limit || defaultLimit, 10), maxLimit);
     query.skip(skip);
     query.limit(limit);
-    // let query = cie10.model.find(filtros).skip(skip).limit(limit).sort('sinonimo');
     query.exec(function (err, data) {
         if (err) {
             return next(err);


### PR DESCRIPTION
- normalizamos el searchterm para evitar errores al entrar paréntesis u otros 

- Es necesario correr este script sobre la col. CIE10 para crear un array de words correspondiente al sinónimo.

>  db.cie10.find({}).forEach( function(myDoc) {
     myDoc.words = myDoc.sinonimo.trim().split(" ");
     //print(myDoc ); 
     db.cie10.save(myDoc);
 } );
