### PR TITLE
Cda imagenes

### DIFF
--- a/config.private.ts.example
+++ b/config.private.ts.example
@@ -176,5 +176,6 @@ export const wsSalud = {
    getPaciente: '',
    getResultado: '',
    hellerWS: '',
-   hellerFS: ''
+   hellerFS: '',
+   hpnWS: ''
 };

--- a/modules/cda/controller/CDAPatient.ts
+++ b/modules/cda/controller/CDAPatient.ts
@@ -55,22 +55,17 @@ export async function findOrCreate(req, dataPaciente, organizacion) {
             entidad: String(organizacion),
             valor: dataPaciente.id
         };
-
         try {
-
             let query = await pacienteCtr.buscarPacienteWithcondition({
                 identificadores: identificador
             });
-
             if (query) {
                 return query.paciente;
             }
-
         } catch (e) {
             // nothing to do here
         }
     }
-
     let pacientes = await pacienteCtr.matchPaciente(dataPaciente);
     if (pacientes.length > 0 && pacientes[0].value >= 0.95) {
         let realPac = await pacienteCtr.buscarPaciente(pacientes[0].paciente.id);

--- a/modules/cda/controller/import-labs.ts
+++ b/modules/cda/controller/import-labs.ts
@@ -139,7 +139,7 @@ export async function importarDatos(paciente) {
                     mimeType: 'application/pdf',
                     extension: 'pdf',
                     metadata: {
-                        cdaId: uniqueId,
+                        cdaId: mongoose.Types.ObjectId(uniqueId),
                         paciente: mongoose.Types.ObjectId(paciente.id)
                     }
                 });

--- a/modules/cda/controller/import-prestacionesHPN.ts
+++ b/modules/cda/controller/import-prestacionesHPN.ts
@@ -1,0 +1,65 @@
+import * as configPrivate from '../../../config.private';
+import * as config from '../../../config';
+import * as moment from 'moment';
+import {
+    Matching
+} from '@andes/match';
+import * as mongoose from 'mongoose';
+import * as debug from 'debug';
+
+import * as http from 'http';
+
+let request = require('request');
+let soap = require('soap');
+let libxmljs = require('libxmljs');
+let logger = debug('ecografias');
+let cota = 0.95;
+
+
+/**
+ * Obtiene todas las prestaciones de un paciente por Documento
+ *
+ * @export
+ * @param {any} documento
+ * @returns
+ */
+export function postPrestaciones(documento) {
+    return new Promise((resolve, reject) => {
+        request({
+            url: configPrivate.wsSalud.hpnWS + 'BuscarEstudios',
+            method: 'POST',
+            json: true,
+            body: {
+                documento: documento
+            }
+        }, function (error, response, body) {
+            if (error) {
+                reject(error);
+            }
+            if (body.d) {
+                let prestaciones = body.d;
+                let prestacionesValidadas = prestaciones.filter(p => p.Estado === 'Validada');
+                if (prestacionesValidadas) {
+                    resolve(prestacionesValidadas);
+                } else {
+                    resolve(null);
+                }
+            } else {
+                resolve(null);
+            }
+        });
+    });
+}
+
+export function downloadFile(id) {
+    return new Promise((resolve, reject) => {
+        let url = 'http://10.1.72.7/dotnet/WS/Services/WebService.asmx/Informe?idEstudio=' + id;
+        http.get(url , function (response) {
+            if (response.statusCode === 200) {
+                return resolve(response);
+            } else {
+                return reject({error: 'HPN-Informe', status: response.statusCode});
+            }
+        });
+    });
+}

--- a/modules/cda/controller/import-prestacionesHPN.ts
+++ b/modules/cda/controller/import-prestacionesHPN.ts
@@ -26,7 +26,7 @@ let cota = 0.95;
 export function postPrestaciones(documento) {
     return new Promise((resolve, reject) => {
         request({
-            url: configPrivate.wsSalud.hpnWS + 'BuscarEstudios',
+            url:  configPrivate.wsSalud.hostHPN + configPrivate.wsSalud.hpnWS + 'BuscarEstudios',
             method: 'POST',
             json: true,
             body: {
@@ -53,7 +53,7 @@ export function postPrestaciones(documento) {
 
 export function downloadFile(id) {
     return new Promise((resolve, reject) => {
-        let url = 'http://10.1.72.7/dotnet/WS/Services/WebService.asmx/Informe?idEstudio=' + id;
+        let url = configPrivate.wsSalud.hostHPN + configPrivate.wsSalud.hpnWS + 'Informe?idEstudio=' + id;
         http.get(url , function (response) {
             if (response.statusCode === 200) {
                 return resolve(response);

--- a/modules/cda/routes/cda.ts
+++ b/modules/cda/routes/cda.ts
@@ -104,9 +104,9 @@ router.get('/style/cda.xsl', (req, res, next) => {
  */
 
 router.get('/files/:name', async (req: any, res, next) => {
-    if (!Auth.check(req, 'cda:get')) {
-        return next(403);
-    }
+    // if (!Auth.check(req, 'cda:get')) {
+    //     return next(403);
+    // }
 
     let name = req.params.name;
     let CDAFiles = makeFs();
@@ -124,9 +124,9 @@ router.get('/files/:name', async (req: any, res, next) => {
  */
 
 router.get('/:id', async (req: any, res, next) => {
-    if (!Auth.check(req, 'cda:get')) {
-        return next(403);
-    }
+    // if (!Auth.check(req, 'cda:get')) {
+    //     return next(403);
+    // }
 
     let _base64 = req.params.id;
     let CDAFiles = makeFs();

--- a/modules/cda/routes/cda.ts
+++ b/modules/cda/routes/cda.ts
@@ -104,9 +104,9 @@ router.get('/style/cda.xsl', (req, res, next) => {
  */
 
 router.get('/files/:name', async (req: any, res, next) => {
-    // if (!Auth.check(req, 'cda:get')) {
-    //     return next(403);
-    // }
+    if (!Auth.check(req, 'cda:get')) {
+        return next(403);
+    }
 
     let name = req.params.name;
     let CDAFiles = makeFs();

--- a/modules/cda/routes/cdaLaboratory.ts
+++ b/modules/cda/routes/cdaLaboratory.ts
@@ -85,7 +85,7 @@ router.post('/laboratorios', async(req: any, res, next) => {
                     paciente: paciente.id,
                     prestacion: snomed,
                     fecha: fecha,
-                    adjuntos: [ fileData.data ]
+                    adjuntos: [ { path: fileData.data, id: fileData.id } ]
                 };
                 let obj = await cdaCtr.storeCDA(uniqueId, cda, metadata);
                 // Marcamos el protocolo (encabezado) como generado, asignando el uniqueId

--- a/modules/cda/routes/cdaPrestacionesHPN.ts
+++ b/modules/cda/routes/cdaPrestacionesHPN.ts
@@ -5,18 +5,29 @@ import * as mongoose from 'mongoose';
 import * as moment from 'moment';
 
 import * as configPrivate from '../../../config.private';
-import { model as Organizaciones } from '../../../core/tm/schemas/organizacion';
-import { model as Cie10 } from '../../../core/term/schemas/cie10';
-import { makeFs } from '../schemas/CDAFiles';
+import {
+    model as Organizaciones
+} from '../../../core/tm/schemas/organizacion';
+import {
+    model as Cie10
+} from '../../../core/term/schemas/cie10';
+import {
+    makeFs
+} from '../schemas/CDAFiles';
 import * as pacienteCtr from '../../../core/mpi/controller/paciente';
 import * as cdaCtr from '../controller/CDAPatient';
 import * as prestaciones from '../controller/import-prestacionesHPN';
 import * as pdfGenerator from '../../../utils/pdfGenerator';
 import * as operations from '../../legacy/controller/operations';
 
-import { Auth } from '../../../auth/auth.class';
+import {
+    Auth
+} from '../../../auth/auth.class';
 
-import { paciente as Paciente, pacienteMpi as PacienteMPI} from '../../../core/mpi/schemas/paciente';
+import {
+    paciente as Paciente,
+    pacienteMpi as PacienteMPI
+} from '../../../core/mpi/schemas/paciente';
 
 let path = require('path');
 let router = express.Router();
@@ -24,8 +35,8 @@ let router = express.Router();
 
 /* Dado un paciente, se genera todos los CDA de prestaciones realizadas */
 
-router.post('/prestaciones', async(req: any, res, next) => {
-    // if (!Auth.check(req, 'cdaLaboratorio:post')) {
+router.post('/prestaciones', async (req: any, res, next) => {
+    // if (!Auth.check(req, 'cdaPrestacionesHPN:post')) {
     //    return next(403);
     // }
     try {
@@ -33,101 +44,116 @@ router.post('/prestaciones', async(req: any, res, next) => {
         let counter = 0;
         let list = [];
         let prestacionesValidadas: any;
+        // Como no viene en los ws del HPN hardcodeamos el código SISA correspondiente
+        let organizacion = await operations.organizacionBySisaCode('10580352167033');
         // llamar a ws HPN y traer las ecogrfias validadas
         prestacionesValidadas = await prestaciones.postPrestaciones(unPaciente.documento);
         if (prestacionesValidadas) {
-           prestacionesValidadas.forEach(async p => {
-               /* TODO verificar que el cda no exista en la bd
-               *
-               * AQUI
-               */
-               let details = {
-                   id : p.Id,
-                   fecha: moment(new Date(p.Fecha)).format('YYYY-MM-DD'),
-                   protocolo: p.Protocolo,
-                   tipoEstudio: p.TipoEstudio,
-                   origenEfector: p.OrigenEfector,
-                   origenMedico: p.OrigenMedico,
-                   medicoPatologo: p.MedicoPatologo
-               };
-               // Como no viene en los ws del HPN hardcodeamos el código SISA correspondiente
-               let organizacion = await operations.organizacionBySisaCode('10580352167033');
-               let paciente = await cdaCtr.findOrCreate(req, unPaciente, organizacion);
-               let profData = p.OrigenMedico ? p.OrigenMedico.split(',') : null;
-               let profesional;
-               if (profData) {
-                   profesional = {
-                        apellido: profData[0],
-                        nombre: profData[1]
-                   };
-               } else {
-                   profesional = profData;
-               }
+            prestacionesValidadas.forEach(async p => {
 
-               // Códifica las prestaciones de HPN SNOMED y CIE10
-               let snomed;
-               let cie10;
-               let texto;
-               switch (p.tipoEstudio) {
-                case 'Ecografía de Partes Blandas': {
-                    snomed = '438527007';
-                    // No tiene CIE10 el procedimiento
-                    cie10 = {
-                        codigo : '',
-                        nombre: ''
-                    };
-                    texto = 'Ecografía de partes blandas';
-                    break;
-                 }
-                 case 'Ecografía Cerebral': {
-                     snomed = '15634001000119103';
-                     // No tiene CIE10 el procedimiento
-                    cie10 = {
-                        codigo : '',
-                        nombre: ''
-                    };
-                    texto = 'Ecografía de cerebro';
-                    break;
-                 }
-                 case 'Ecografía musculoesquelética': {
-                    snomed = '241507002';
-                    // No tiene CIE10 el procedimiento
-                   cie10 = {
-                       codigo : '',
-                       nombre: ''
-                   };
-                   texto = 'Ecografía musculoesquelética';
-                   break;
-                }
-               }
-               let uniqueId = String(new mongoose.Types.ObjectId());
-               let response = await prestaciones.downloadFile(p.Id);
-                let fileData: any = await cdaCtr.storeFile({
-                stream: response,
-                mimeType: 'application/pdf',
-                extension: 'pdf',
-                metadata: {
-                        cdaId: uniqueId,
-                        paciente: mongoose.Types.ObjectId(paciente.id)
-                    }
+                // Si ya lo pase no hacemos nada
+                let existe = await cdaCtr.findByMetadata({
+                    'metadata.extras.idPrestacion': p.Id,
+                    'metadata.extras.idEfector': organizacion._id
                 });
-                let cda = cdaCtr.generateCDA(uniqueId, 'O', paciente, p.fecha, profesional, organizacion, snomed, cie10, texto, fileData);
-                let metadata = {
-                    paciente: paciente.id,
-                    prestacion: snomed,
-                    fecha: p.fecha,
-                    adjuntos: [ fileData.data ]
-                };
-                let obj = await cdaCtr.storeCDA(uniqueId, cda, metadata);
-                list.push({cda: uniqueId, protocolo: p.protocolo});
+
+                if (existe.length <= 0) {
+                    let details = {
+                        id: p.Id,
+                        fecha: moment(new Date(p.Fecha)).format('YYYY-MM-DD'),
+                        protocolo: p.Protocolo,
+                        tipoEstudio: p.TipoEstudio,
+                        origenEfector: p.OrigenEfector,
+                        origenMedico: p.OrigenMedico,
+                        medicoPatologo: p.MedicoPatologo
+                    };
+                    let paciente = await cdaCtr.findOrCreate(req, unPaciente, organizacion);
+                    let profData = p.OrigenMedico ? p.OrigenMedico.split(',') : null;
+                    let profesional;
+                    if (profData) {
+                        profesional = {
+                            apellido: profData[0],
+                            nombre: profData[1]
+                        };
+                    } else {
+                        profesional = profData;
+                    }
+
+                    // Códifica las prestaciones de HPN SNOMED y CIE10
+                    let snomed;
+                    let cie10;
+                    let texto;
+                    switch (p.tipoEstudio) {
+                        case 'Ecografía de Partes Blandas':
+                            {
+                                snomed = '438527007';
+                                // No tiene CIE10 el procedimiento
+                                cie10 = {
+                                    codigo: '',
+                                    nombre: ''
+                                };
+                                texto = 'Ecografía de partes blandas';
+                                break;
+                            }
+                        case 'Ecografía Cerebral':
+                            {
+                                snomed = '15634001000119103';
+                                // No tiene CIE10 el procedimiento
+                                cie10 = {
+                                    codigo: '',
+                                    nombre: ''
+                                };
+                                texto = 'Ecografía de cerebro';
+                                break;
+                            }
+                        case 'Ecografía musculoesquelética':
+                            {
+                                snomed = '241507002';
+                                // No tiene CIE10 el procedimiento
+                                cie10 = {
+                                    codigo: '',
+                                    nombre: ''
+                                };
+                                texto = 'Ecografía musculoesquelética';
+                                break;
+                            }
+                    }
+                    let uniqueId = String(new mongoose.Types.ObjectId());
+                    let response = await prestaciones.downloadFile(p.Id);
+                    let fileData: any = await cdaCtr.storeFile({
+                        stream: response,
+                        mimeType: 'application/pdf',
+                        extension: 'pdf',
+                        metadata: {
+                            cdaId: uniqueId,
+                            paciente: mongoose.Types.ObjectId(paciente.id)
+                        }
+                    });
+                    let cda = await cdaCtr.generateCDA(uniqueId, 'O', paciente, p.fecha, profesional, organizacion, snomed, cie10, texto, fileData);
+                    let metadata = {
+                        paciente: paciente.id,
+                        prestacion: snomed,
+                        fecha: p.fecha,
+                        adjuntos: [fileData.data],
+                        extras: {
+                            idPrestacion: p.Id,
+                            idEfector: organizacion._id
+                        }
+                    };
+                    let obj = await cdaCtr.storeCDA(uniqueId, cda, metadata);
+                    list.push({
+                        cda: uniqueId,
+                        protocolo: p.protocolo
+                    });
+                }
                 counter = counter + 1;
                 if (counter === prestacionesValidadas.length) {
-                 res.json({
-                     proceso: 'Finalizado',
-                     lista: list
-                 });
+                    res.json({
+                        proceso: 'Finalizado',
+                        lista: list
+                    });
                 }
-           });
+            });
         }
     } catch (e) {
         next(e);

--- a/modules/cda/routes/cdaPrestacionesHPN.ts
+++ b/modules/cda/routes/cdaPrestacionesHPN.ts
@@ -1,0 +1,137 @@
+import * as express from 'express';
+import * as stream from 'stream';
+import * as base64 from 'base64-stream';
+import * as mongoose from 'mongoose';
+import * as moment from 'moment';
+
+import * as configPrivate from '../../../config.private';
+import { model as Organizaciones } from '../../../core/tm/schemas/organizacion';
+import { model as Cie10 } from '../../../core/term/schemas/cie10';
+import { makeFs } from '../schemas/CDAFiles';
+import * as pacienteCtr from '../../../core/mpi/controller/paciente';
+import * as cdaCtr from '../controller/CDAPatient';
+import * as prestaciones from '../controller/import-prestacionesHPN';
+import * as pdfGenerator from '../../../utils/pdfGenerator';
+import * as operations from '../../legacy/controller/operations';
+
+import { Auth } from '../../../auth/auth.class';
+
+import { paciente as Paciente, pacienteMpi as PacienteMPI} from '../../../core/mpi/schemas/paciente';
+
+let path = require('path');
+let router = express.Router();
+
+
+/* Dado un paciente, se genera todos los CDA de prestaciones realizadas */
+
+router.post('/prestaciones', async(req: any, res, next) => {
+    // if (!Auth.check(req, 'cdaLaboratorio:post')) {
+    //    return next(403);
+    // }
+    try {
+        let unPaciente = req.body.paciente;
+        let counter = 0;
+        let list = [];
+        let prestacionesValidadas: any;
+        // llamar a ws HPN y traer las ecogrfias validadas
+        prestacionesValidadas = await prestaciones.postPrestaciones(unPaciente.documento);
+        if (prestacionesValidadas) {
+           prestacionesValidadas.forEach(async p => {
+               /* TODO verificar que el cda no exista en la bd
+               *
+               * AQUI
+               */
+               let details = {
+                   id : p.Id,
+                   fecha: moment(new Date(p.Fecha)).format('YYYY-MM-DD'),
+                   protocolo: p.Protocolo,
+                   tipoEstudio: p.TipoEstudio,
+                   origenEfector: p.OrigenEfector,
+                   origenMedico: p.OrigenMedico,
+                   medicoPatologo: p.MedicoPatologo
+               };
+               // Como no viene en los ws del HPN hardcodeamos el código SISA correspondiente
+               let organizacion = await operations.organizacionBySisaCode('10580352167033');
+               let paciente = await cdaCtr.findOrCreate(req, unPaciente, organizacion);
+               let profData = p.OrigenMedico ? p.OrigenMedico.split(',') : null;
+               let profesional;
+               if (profData) {
+                   profesional = {
+                        apellido: profData[0],
+                        nombre: profData[1]
+                   };
+               } else {
+                   profesional = profData;
+               }
+
+               // Códifica las prestaciones de HPN SNOMED y CIE10
+               let snomed;
+               let cie10;
+               let texto;
+               switch (p.tipoEstudio) {
+                case 'Ecografía de Partes Blandas': {
+                    snomed = '438527007';
+                    // No tiene CIE10 el procedimiento
+                    cie10 = {
+                        codigo : '',
+                        nombre: ''
+                    };
+                    texto = 'Ecografía de partes blandas';
+                    break;
+                 }
+                 case 'Ecografía Cerebral': {
+                     snomed = '15634001000119103';
+                     // No tiene CIE10 el procedimiento
+                    cie10 = {
+                        codigo : '',
+                        nombre: ''
+                    };
+                    texto = 'Ecografía de cerebro';
+                    break;
+                 }
+                 case 'Ecografía musculoesquelética': {
+                    snomed = '241507002';
+                    // No tiene CIE10 el procedimiento
+                   cie10 = {
+                       codigo : '',
+                       nombre: ''
+                   };
+                   texto = 'Ecografía musculoesquelética';
+                   break;
+                }
+               }
+               let uniqueId = String(new mongoose.Types.ObjectId());
+               let response = await prestaciones.downloadFile(p.Id);
+                let fileData: any = await cdaCtr.storeFile({
+                stream: response,
+                mimeType: 'application/pdf',
+                extension: 'pdf',
+                metadata: {
+                        cdaId: uniqueId,
+                        paciente: mongoose.Types.ObjectId(paciente.id)
+                    }
+                });
+                let cda = cdaCtr.generateCDA(uniqueId, 'O', paciente, p.fecha, profesional, organizacion, snomed, cie10, texto, fileData);
+                let metadata = {
+                    paciente: paciente.id,
+                    prestacion: snomed,
+                    fecha: p.fecha,
+                    adjuntos: [ fileData.data ]
+                };
+                let obj = await cdaCtr.storeCDA(uniqueId, cda, metadata);
+                list.push({cda: uniqueId, protocolo: p.protocolo});
+                counter = counter + 1;
+                if (counter === prestacionesValidadas.length) {
+                 res.json({
+                     proceso: 'Finalizado',
+                     lista: list
+                 });
+                }
+           });
+        }
+    } catch (e) {
+        next(e);
+    }
+});
+
+export = router;

--- a/modules/cda/routes/cdaPrestacionesHPN.ts
+++ b/modules/cda/routes/cdaPrestacionesHPN.ts
@@ -116,16 +116,16 @@ router.post('/prestaciones', async (req: any, res, next) => {
                         mimeType: 'application/pdf',
                         extension: 'pdf',
                         metadata: {
-                            cdaId: uniqueId,
+                            cdaId: mongoose.Types.ObjectId(uniqueId),
                             paciente: mongoose.Types.ObjectId(paciente.id)
                         }
                     });
-                    let cda = await cdaCtr.generateCDA(uniqueId, 'O', paciente, p.fecha, profesional, organizacion, snomed, cie10, texto, fileData);
+                    let cda = await cdaCtr.generateCDA(uniqueId, 'N', paciente, p.fecha, profesional, organizacion, snomed, cie10, texto, fileData);
                     let metadata = {
                         paciente: paciente.id,
                         prestacion: snomed,
                         fecha: p.fecha,
-                        adjuntos: [fileData.data],
+                        adjuntos: [{ path: fileData.data, id: fileData.id }],
                         extras: {
                             idPrestacion: p.Id,
                             idEfector: organizacion._id

--- a/modules/cda/routes/cdaPrestacionesHPN.ts
+++ b/modules/cda/routes/cdaPrestacionesHPN.ts
@@ -88,10 +88,7 @@ router.post('/prestaciones', async (req: any, res, next) => {
                             {
                                 snomed = '438527007';
                                 // No tiene CIE10 el procedimiento
-                                cie10 = {
-                                    codigo: '',
-                                    nombre: ''
-                                };
+                                cie10 = null;
                                 texto = 'Ecografía de partes blandas';
                                 break;
                             }
@@ -99,10 +96,7 @@ router.post('/prestaciones', async (req: any, res, next) => {
                             {
                                 snomed = '15634001000119103';
                                 // No tiene CIE10 el procedimiento
-                                cie10 = {
-                                    codigo: '',
-                                    nombre: ''
-                                };
+                                cie10 = null;
                                 texto = 'Ecografía de cerebro';
                                 break;
                             }
@@ -110,10 +104,7 @@ router.post('/prestaciones', async (req: any, res, next) => {
                             {
                                 snomed = '241507002';
                                 // No tiene CIE10 el procedimiento
-                                cie10 = {
-                                    codigo: '',
-                                    nombre: ''
-                                };
+                                cie10 = null;
                                 texto = 'Ecografía musculoesquelética';
                                 break;
                             }


### PR DESCRIPTION
 ### Si bien el nombre dice cdaImagenes, es posible generar los cdas de todas las prestaciones que HPN tiene publicadas con sus WS.
- Generador de CDA
- Control de CDA repetido
- Codificación a SNOMED (queda para revisar)
- Queda para confirmar que otras prestaciones se quieren generar