### PR TITLE
fix Issue app#460

### DIFF
--- a/modules/turnos/controller/turnosController.ts
+++ b/modules/turnos/controller/turnosController.ts
@@ -40,6 +40,7 @@ export function getTurno(req) {
                 '$group': {
                     '_id': '$_id.id',
                     'agenda_id': { $first: '$agenda_id' },
+                    'bloque_id': { $first: '$_id.bloqueId' },
                     'organizacion': { $first: '$organizacion' },
                     'profesionales': { $first: '$profesionales' },
                     'bloques': { $push: { '_id': '$_id.bloqueId', 'turnos': '$turnos' } }
@@ -118,6 +119,7 @@ export function getTurno(req) {
                     turno = elem.bloques.turnos;
                     turno.id = turno._id;
                     turno.agenda_id = elem.agenda_id;
+                    turno.bloque_id = elem.bloque_id;
                     turno.organizacion = elem.organizacion;
                     turno.profesionales = elem.profesionales;
                     turno.paciente = (elem.pacientes_docs && elem.pacientes_docs.length > 0) ? elem.pacientes_docs[0] : elem.bloques.turnos.paciente;

--- a/modules/turnos/routes/turno.ts
+++ b/modules/turnos/routes/turno.ts
@@ -237,8 +237,15 @@ router.patch('/turno/:idTurno/:idBloque/:idAgenda', function (req, res, next) {
             return (t.id === req.params.idTurno);
         });
         let update = {};
-        let etiquetaAvisoSuspension: string = 'bloques.' + indexBloque + '.turnos.' + indexTurno + '.avisoSuspension';
-        update[etiquetaAvisoSuspension] = req.body.avisoSuspension;
+        if (req.body.avisoSuspension) {
+            let etiquetaAvisoSuspension: string = 'bloques.' + indexBloque + '.turnos.' + indexTurno + '.avisoSuspension';
+            update[etiquetaAvisoSuspension] = req.body.avisoSuspension;
+        }
+        if (req.body.motivoConsulta) {
+            let etiquetaMotivoConsulta: string = 'bloques.' + indexBloque + '.turnos.' + indexTurno + '.motivoConsulta';
+            update[etiquetaMotivoConsulta] = req.body.motivoConsulta;
+
+        }
         let query = {
             _id: req.params.idAgenda,
         };


### PR DESCRIPTION
- La operación que devuelve todos los turnos de un paciente, en cada turno devuelve ahora el id de bloque (junto con el id de agenda que ya devolvía) para facilitar los patchs de esos turnos.

- Se agrega la etiqueta de motivo suspensión al patch del turno.