### PR TITLE
Fix pacientes sin dni

### DIFF
--- a/modules/obraSocial/routes/obraSocial.ts
+++ b/modules/obraSocial/routes/obraSocial.ts
@@ -8,7 +8,7 @@ let to_json = require('xmljson').to_json;
 
 let router = express.Router();
 
-router.get('/puco/:documento', async function (req, res, next) {
+router.get('/puco/:documento?', async function (req, res, next) {
     if (req.params.documento) {
         try {
             let respuesta: any = await getOs(req.params.documento);
@@ -19,9 +19,11 @@ router.get('/puco/:documento', async function (req, res, next) {
                 res.json({ nombre: 'Sumar', codigo: '499' });
             }
         } catch (e) {
-            // default: sumar
             return next(e);
         }
+    } else {
+        // default: sumar
+        res.json({ nombre: 'Sumar', codigo: '499' });
     }
 });
 /**

--- a/modules/turnos/routes/carpetaPaciente.ts
+++ b/modules/turnos/routes/carpetaPaciente.ts
@@ -92,6 +92,8 @@ router.get('/carpetasPacientes/:id*?', function (req, res, next) {
                 }
 
             });
+        } else {
+            res.json({});
         }
     }
 


### PR DESCRIPTION
agregamos dos fixes para querys a la API con pacientes sin dni

en la ruta de obras sociales y en la ruta de carpetaPaciente (quedaba en pending)