### PR TITLE
issue #576  indicar primera vez de c2

### DIFF
--- a/modules/rup/schemas/prestacion.registro.ts
+++ b/modules/rup/schemas/prestacion.registro.ts
@@ -33,11 +33,7 @@ schema.add({
         type: Boolean,
         default: false
     },
-    esPrimeraVez: {
-        type: String,
-        enum: ['Si', 'No', ''],
-        default: ''
-    },
+    esPrimeraVez: Boolean,
     // Almacena el valor del átomo, molécula o fórmula.
     // Para el caso de las moléculas, el valor puede ser nulo.
     valor: mongoose.Schema.Types.Mixed,

--- a/modules/rup/schemas/prestacion.registro.ts
+++ b/modules/rup/schemas/prestacion.registro.ts
@@ -34,8 +34,9 @@ schema.add({
         default: false
     },
     esPrimeraVez: {
-        type: Boolean,
-        default: false
+        type: String,
+        enum: ['Si', 'No', ''],
+        default: ''
     },
     // Almacena el valor del átomo, molécula o fórmula.
     // Para el caso de las moléculas, el valor puede ser nulo.


### PR DESCRIPTION
Se cambia la variable esPrimeraVez en el esquema de Registro. Se quita el valor por defecto. En app se valida que se elija SI o NO