### PR TITLE
Reportes C2 - Filtro primera vez

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,18 @@
 * Historial de turnos de paciente: Se muestra el histórico del paciente de todos los turnos en cualquier efector
 * Reportes C2: se agrega detalle de los pacientes por diagnóstico c2. Se agrega control que los diagnósticos sean Primera Vez y principal. [#317](https://github.com/andes/api/pull/305)
 * Fix de screening de otoemisión
+
+## [3.2.0] - 2018-06-21
+
+#### Added
+
+* Se introducen mejoras al scheduler
+* Cada ejecución se realiza en un proceso aparte.
+* Se corrigen los Jobs que notifiquen cuando termina sus proceso.
+* Agrega control de los procesos hijos que se están corriendo.
+* Se previene el solapamiento de jobs.
+
+## [3.2.1] - 2018-06-25
+
+* Reporte C2: el reporte verifica sólo los diagnósticos marcados como primera vez
+(https://github.com/andes/api/pull/333)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "API para ANDES",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Filtra sólo los diagnósticos marcados como primera vez para mostrar en Reporte C2