### PR TITLE
Snomed - Buscar palabras con la lera ñ

### DIFF
--- a/core/term/routes/snomed.ts
+++ b/core/term/routes/snomed.ts
@@ -70,7 +70,7 @@ router.get('/snomed', function (req, res, next) {
             let words = req.query.search.split(' ');
             words.forEach(function (word) {
                 // normalizamos cada una de las palabras como hace SNOMED para poder buscar palabra a palabra
-                word = word.replace(/([-()\[\]{}+?*.$\^|,:#<!\\])/g, '\\$1').replace(/\x08/g, '\\x08');
+                word = word.replace(/([-()\[\]{}+?*.$\^|,:#<!\\])/g, '\\$1').replace(/\x08/g, '\\x08').replace('ñ', 'n');
                 let expWord = '^' + utils.removeDiacritics(word) + '.*';
 
                 // agregamos la palabra a la condicion


### PR DESCRIPTION
### Requerimiento
* Poder buscar palabras con la letra ñ.

### Funcionalidad desarrollada
1. Al momento de buscar en SNOMED, se reemplaza la 'ñ' por la 'n', ya que la colección de SNOMED tiene indezada las palabras con la 'n'

### UserStories llegó a completarse
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [ ] Si
- [X] No
