### PR TITLE
Integración HPN: Request Timeout

### DIFF
--- a/modules/turnos/controller/agendasHPNCacheController.ts
+++ b/modules/turnos/controller/agendasHPNCacheController.ts
@@ -11,7 +11,8 @@ let connection = {
     password: configPrivate.conSqlHPN.auth.password,
     server: configPrivate.conSqlHPN.serverSql.server,
     database: configPrivate.conSqlHPN.serverSql.database,
-    port: configPrivate.conSqlHPN.serverSql.port // solo para test! BORRAR
+    port: configPrivate.conSqlHPN.serverSql.port,
+    requestTimeout: 30000
 };
 
 export async function integracion() {


### PR DESCRIPTION
Agregamos un setRequestTimeout de msssql, para que no falle el insert en sql de HPN. Esto se debe a que hay muchos datos en la tabla y el insert tarda en terminar.

### Funcionalidad desarrollada 
Se agregó el parámetro  requestTimeout: 30000 en el objeto de la conexión.

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No