### PR TITLE
Integracion HPN: tipo de documento

### DIFF
--- a/modules/turnos/controller/pacienteHPNController.ts
+++ b/modules/turnos/controller/pacienteHPNController.ts
@@ -67,13 +67,10 @@ export async function savePaciente(paciente: any, transaction) {
 }
 
 export async function getDatosPaciente(tipoDocumento, documento, pool) {
-    // Agregar indice a HC_Documento de Historias_Clinicas
-    // idPaciente = Codigo "id" de la tabla Historias_Clinicas y idHistoria es el Número de carpeta.
     let query = 'SELECT h.Codigo as idHistoria, p.id as idPaciente ' +
-                'FROM Historias_Clinicas h ' +
-                'inner join Pacientes p on p.legacy_idHistoriaClinica=h.codigo ' +
-                'WHERE HC_Tipo_de_documento = @tipoDocumento ' +
-                'AND h.HC_Documento = @documento';
+    'FROM Historias_Clinicas h ' + 'inner join Pacientes p on p.legacy_idHistoriaClinica=h.codigo ' +
+    'WHERE h.HC_Documento = @documento';
+
     let result = await pool.request()
         .input('documento', sql.VarChar(50), documento)
         .input('tipoDocumento', sql.VarChar(50), tipoDocumento)

--- a/modules/turnos/controller/turnoHPNCacheController.ts
+++ b/modules/turnos/controller/turnoHPNCacheController.ts
@@ -167,7 +167,7 @@ async function updateTurno(id, estado, pool, transaction) {
         idEstado = 50; // Prestación ha sido liberada
     }
     let query = 'UPDATE dbo.Prestaciones_Worklist SET ' +
-        'idEstado=' + idEstado + ' where andesId=' + '\'' + id + '\'';
+        'idEstado=' + idEstado + ' where andesId=\'' + id + '\'' ;
     return await new sql.Request(transaction)
         .query(query)
         .catch(err => {


### PR DESCRIPTION
INTEGRACION HPN: Solucionamos el bug por tipo de documento y el update de los turnos existentes.

### Funcionalidad desarrollada 
1. Quitamos de la consulta SQL el filtro por tipo de documento, ya que daba conflicto con pacientes extranjeros.
2. Bug en el update, el id es de tipo string y en sql debe ir entre comillas simples.
### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No


