### PR TITLE
verificación de paciente sin dni

### DIFF
--- a/modules/turnos/controller/pacienteHPNController.ts
+++ b/modules/turnos/controller/pacienteHPNController.ts
@@ -8,7 +8,7 @@ export async function savePaciente(paciente: any, transaction) {
     let hcTipo = 1;
     let hcNumero = 'PDR' + paciente.documento;
     let tipoDocumento = 'DNI';
-    let nroDocumento = paciente.documento;
+    let nroDocumento = (paciente.documento) ? paciente.documento : paciente._id;
     let apellido = paciente.apellido;
     let nombre = paciente.nombre;
     let estadoCivil =  (paciente.estadoCivil ? paciente.estadoCivil : null);

--- a/modules/turnos/controller/pacienteHPNController.ts
+++ b/modules/turnos/controller/pacienteHPNController.ts
@@ -6,7 +6,7 @@ export async function savePaciente(paciente: any, transaction) {
     let fechaUltimoAcceso = fechaCreacion;
     let fechaActualizacion = fechaCreacion;
     let hcTipo = 1;
-    let hcNumero = 'PDR' + paciente.documento;
+    let hcNumero = (paciente.documento) ? 'PDR' + paciente.documento : 'PDR' + paciente._id;
     let tipoDocumento = 'DNI';
     let nroDocumento = (paciente.documento) ? paciente.documento : paciente._id;
     let apellido = paciente.apellido;

--- a/modules/turnos/controller/turnoHPNCacheController.ts
+++ b/modules/turnos/controller/turnoHPNCacheController.ts
@@ -10,7 +10,13 @@ export async function saveTurnos(idAgendaAndes, bloque, idTipoPrestacion, pool, 
             (!await (getIdTurnoHPN(turno._id, pool)))) {
             let result = await pacientes.buscarPaciente(turno.paciente.id);
             let paciente = result.paciente;
-            let datosPaciente = paciente.documento ? await pacienteCtrl.getDatosPaciente('DNI', paciente.documento, pool) : null;
+            let doc;
+            if (paciente.documento) {
+                doc = paciente.documento;
+            } else {
+                doc = paciente._id;
+            }
+            let datosPaciente =  await pacienteCtrl.getDatosPaciente('DNI', doc, pool);
             if (!datosPaciente) {
                 datosPaciente = await pacienteCtrl.savePaciente(paciente, transaction);
             }
@@ -28,8 +34,13 @@ export async function saveSobreturno(idAgendaAndes, sobreturno, idTipoPrestacion
         (!await (getIdTurnoHPN(sobreturno._id, pool)))) {
         let result = await pacientes.buscarPaciente(sobreturno.paciente.id);
         let paciente = result.paciente;
-
-        let datosPaciente = paciente.documento ? await pacienteCtrl.getDatosPaciente('DNI', paciente.documento, pool) : null;
+        let doc;
+        if (paciente.documento) {
+            doc = paciente.documento;
+        } else {
+            doc = paciente._id;
+        }
+        let datosPaciente =  await pacienteCtrl.getDatosPaciente('DNI', doc, pool);
         if (!datosPaciente) {
             datosPaciente = await pacienteCtrl.savePaciente(paciente, transaction);
         }

--- a/modules/turnos/controller/turnoHPNCacheController.ts
+++ b/modules/turnos/controller/turnoHPNCacheController.ts
@@ -10,8 +10,7 @@ export async function saveTurnos(idAgendaAndes, bloque, idTipoPrestacion, pool, 
             (!await (getIdTurnoHPN(turno._id, pool)))) {
             let result = await pacientes.buscarPaciente(turno.paciente.id);
             let paciente = result.paciente;
-
-            let datosPaciente = await pacienteCtrl.getDatosPaciente('DNI', paciente.documento, pool);
+            let datosPaciente = paciente.documento ? await pacienteCtrl.getDatosPaciente('DNI', paciente.documento, pool) : null;
             if (!datosPaciente) {
                 datosPaciente = await pacienteCtrl.savePaciente(paciente, transaction);
             }
@@ -30,7 +29,7 @@ export async function saveSobreturno(idAgendaAndes, sobreturno, idTipoPrestacion
         let result = await pacientes.buscarPaciente(sobreturno.paciente.id);
         let paciente = result.paciente;
 
-        let datosPaciente = await pacienteCtrl.getDatosPaciente('DNI', paciente.documento, pool);
+        let datosPaciente = paciente.documento ? await pacienteCtrl.getDatosPaciente('DNI', paciente.documento, pool) : null;
         if (!datosPaciente) {
             datosPaciente = await pacienteCtrl.savePaciente(paciente, transaction);
         }

--- a/modules/turnos/controller/turnoHPNCacheController.ts
+++ b/modules/turnos/controller/turnoHPNCacheController.ts
@@ -11,10 +11,11 @@ export async function saveTurnos(idAgendaAndes, bloque, idTipoPrestacion, pool, 
             let result = await pacientes.buscarPaciente(turno.paciente.id);
             let paciente = result.paciente;
 
-            let datosPaciente = await pacienteCtrl.getDatosPaciente('DNI', paciente, pool);
+            let datosPaciente = await pacienteCtrl.getDatosPaciente('DNI', paciente, transaction);
 
             if (!datosPaciente) {
-                datosPaciente = await pacienteCtrl.savePaciente(paciente, transaction);
+                await pacienteCtrl.savePaciente(paciente, transaction);
+                datosPaciente = await pacienteCtrl.getDatosPaciente('DNI', paciente, transaction);
             }
             await saveTurno(idAgendaAndes, turno, datosPaciente, bloque.duracionTurno, idTipoPrestacion, pool, transaction);
         }

--- a/modules/turnos/controller/turnoHPNCacheController.ts
+++ b/modules/turnos/controller/turnoHPNCacheController.ts
@@ -10,13 +10,9 @@ export async function saveTurnos(idAgendaAndes, bloque, idTipoPrestacion, pool, 
             (!await (getIdTurnoHPN(turno._id, pool)))) {
             let result = await pacientes.buscarPaciente(turno.paciente.id);
             let paciente = result.paciente;
-            let doc;
-            if (paciente.documento) {
-                doc = paciente.documento;
-            } else {
-                doc = paciente._id;
-            }
-            let datosPaciente =  await pacienteCtrl.getDatosPaciente('DNI', doc, pool);
+
+            let datosPaciente = await pacienteCtrl.getDatosPaciente('DNI', paciente, pool);
+
             if (!datosPaciente) {
                 datosPaciente = await pacienteCtrl.savePaciente(paciente, transaction);
             }
@@ -34,13 +30,8 @@ export async function saveSobreturno(idAgendaAndes, sobreturno, idTipoPrestacion
         (!await (getIdTurnoHPN(sobreturno._id, pool)))) {
         let result = await pacientes.buscarPaciente(sobreturno.paciente.id);
         let paciente = result.paciente;
-        let doc;
-        if (paciente.documento) {
-            doc = paciente.documento;
-        } else {
-            doc = paciente._id;
-        }
-        let datosPaciente =  await pacienteCtrl.getDatosPaciente('DNI', doc, pool);
+
+        let datosPaciente = await pacienteCtrl.getDatosPaciente('DNI', paciente, pool);
         if (!datosPaciente) {
             datosPaciente = await pacienteCtrl.savePaciente(paciente, transaction);
         }
@@ -177,7 +168,7 @@ async function updateTurno(id, estado, pool, transaction) {
         idEstado = 50; // Prestación ha sido liberada
     }
     let query = 'UPDATE dbo.Prestaciones_Worklist SET ' +
-        'idEstado=' + idEstado + ' where andesId=\'' + id + '\'' ;
+        'idEstado=' + idEstado + ' where andesId=\'' + id + '\'';
     return await new sql.Request(transaction)
         .query(query)
         .catch(err => {


### PR DESCRIPTION
INTEGRACION HPN: 
1) Verificación del documento del paciente. Si le dieron un turno a un paciente temporal sin dni, se le asigna el objectId del paciente para guardarlo en la bd del HPN.
2) Si es una agenda 100% autocitada, se pone con estado publicada en Prestaciones 2.0
3) Se creo retry and fail. Si por algún motivo la transacción falla, prueba 2 veces más y cambia el estado a estadoIntegracion = Fail para evitar que se acumulen las agendas.

### Bug
Bug encontrado durante el uso en producción.
### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No
