### PR TITLE
V3.6.1

### DIFF
--- a/modules/turnos/controller/pacienteHPNController.ts
+++ b/modules/turnos/controller/pacienteHPNController.ts
@@ -1,19 +1,25 @@
 import * as sql from 'mssql';
-import * as moment from 'moment';
 
 export async function savePaciente(paciente: any, transaction) {
+
+    let conDni = true;
+    if (!paciente.documento) {
+        conDni = false;
+        paciente.documento = await createPacienteSinDocumento(transaction);
+    }
     let fechaCreacion = new Date();
     let fechaUltimoAcceso = fechaCreacion;
     let fechaActualizacion = fechaCreacion;
-    let hcTipo = 1;
+    let hcTipo = conDni ? 1 : 3; // Si no tiene DNI el hcTipo es SN
     let hcNumero = 'PDR' + paciente.documento;
-    let tipoDocumento = 'DNI';
+    let tipoDocumento = conDni ? 'DNI' : 'SN';
     let nroDocumento = paciente.documento;
     let apellido = paciente.apellido;
     let nombre = paciente.nombre;
-    let estadoCivil =  (paciente.estadoCivil ? paciente.estadoCivil : null);
+    let estadoCivil = (paciente.estadoCivil ? paciente.estadoCivil : null);
     let fechaNacimiento = (paciente.fechaNacimiento ? paciente.fechaNacimiento : null);
     let sexo = paciente.sexo;
+    let andesId = paciente._id;
 
     let query = 'INSERT INTO dbo.Historias_Clinicas ' +
         '(HC_Fecha_de_creacion ' +
@@ -27,8 +33,9 @@ export async function savePaciente(paciente: any, transaction) {
         ',HC_Nombre ' +
         ',HC_Estado_Civil ' +
         ',HC_Sexo ' +
-        ',HC_Nacimiento_Fecha) ' +
-    'VALUES (' +
+        ',HC_Nacimiento_Fecha ' +
+        ',andesId) ' +
+        'VALUES (' +
         '@fechaCreacion, ' +
         '@fechaUltimoAcceso, ' +
         '@fechaActualizacion, ' +
@@ -40,10 +47,10 @@ export async function savePaciente(paciente: any, transaction) {
         '@nombre,' +
         '@estadoCivil, ' +
         '@sexo, ' +
-        '@fechaNacimiento) ' +
+        '@fechaNacimiento, ' +
+        '@andesId) ' +
         'SELECT SCOPE_IDENTITY() AS idHistoria';
-
-    return await new sql.Request(transaction)
+        return new sql.Request(transaction)
         .input('fechaCreacion', sql.DateTime, fechaCreacion)
         .input('fechaUltimoAcceso', sql.DateTime, fechaUltimoAcceso)
         .input('fechaActualizacion', sql.DateTime, fechaActualizacion)
@@ -56,28 +63,65 @@ export async function savePaciente(paciente: any, transaction) {
         .input('estadoCivil', sql.VarChar(10), estadoCivil)
         .input('sexo', sql.VarChar(10), sexo)
         .input('fechaNacimiento', sql.DateTime, fechaNacimiento)
+        .input('andesId', sql.VarChar(50), andesId)
         .query(query).then(result => {
             return {
                 idHistoria: result.recordset[0].codigo,
-                idPaciente: result.recordset[0].idPaciente
+               // idPaciente: result.recordset[0].idPaciente
             };
         }).catch(err => {
             throw err;
         });
 }
 
-export async function getDatosPaciente(tipoDocumento, documento, pool) {
-    let query = 'SELECT h.Codigo as idHistoria, p.id as idPaciente ' +
-    'FROM Historias_Clinicas h ' + 'inner join Pacientes p on p.legacy_idHistoriaClinica=h.codigo ' +
-    'WHERE h.HC_Documento = @documento';
+export async function getDatosPaciente(tipoDocumento, paciente, transaction) {
+    let documento = paciente.documento;
+    let andesId = paciente._id;
 
-    let result = await pool.request()
-        .input('documento', sql.VarChar(50), documento)
-        .input('tipoDocumento', sql.VarChar(50), tipoDocumento)
-        .query(query)
-        .catch(err => {
-            throw err;
-        });
+    if (documento) {
+        let query = 'SELECT h.Codigo as idHistoria, p.id as idPaciente, HC_Tipo, HC_Fecha_Actualizacion ' +
+            'FROM Historias_Clinicas h ' + 'inner join Pacientes p on p.legacy_idHistoriaClinica=h.codigo ' +
+            'WHERE h.HC_Documento = @documento order by HC_Fecha_Actualizacion desc ';
 
-    return result.recordset[0];
+        let result = await transaction.request()
+            .input('documento', sql.VarChar(50), documento)
+            .input('tipoDocumento', sql.VarChar(50), tipoDocumento)
+            .query(query)
+            .catch(err => {
+                throw err;
+            });
+        if (result.recordset.length > 0) {
+            let registros = result.recordset;
+            let reg = registros.find(record => record.HC_TIpo === 1);
+            if (!reg) {
+                return result.recordset[0]; // Sino devuelvo el PDR
+            } else {
+                return reg;
+            }
+        } else {
+            return null;
+        }
+    } else {
+        // Para el caso de los pacientes que vienen sin DNI desde andes, pero que fueron creados con numero SN
+        let query = 'SELECT h.Codigo as idHistoria, p.id as idPaciente ' +
+            'FROM Historias_Clinicas h ' + 'inner join Pacientes p on p.legacy_idHistoriaClinica=h.codigo ' +
+            'WHERE h.andesId = @andesId';
+
+        let result = await transaction.request()
+            .input('andesId', sql.VarChar(50), andesId)
+            .query(query)
+            .catch(err => {
+                throw err;
+            });
+        return result.recordset[0];
+    }
+}
+
+export async function createPacienteSinDocumento(transaction) {
+    let result = await new sql.Request(transaction)
+        .input('sistema', sql.Int, 6)
+        .output('nextKey', sql.Int)
+        .execute('hsp_Keys');
+
+    return result.output.nextKey;
 }

--- a/modules/turnos/controller/turnoHPNCacheController.ts
+++ b/modules/turnos/controller/turnoHPNCacheController.ts
@@ -11,9 +11,11 @@ export async function saveTurnos(idAgendaAndes, bloque, idTipoPrestacion, pool, 
             let result = await pacientes.buscarPaciente(turno.paciente.id);
             let paciente = result.paciente;
 
-            let datosPaciente = await pacienteCtrl.getDatosPaciente('DNI', paciente.documento, pool);
+            let datosPaciente = await pacienteCtrl.getDatosPaciente('DNI', paciente, transaction);
+
             if (!datosPaciente) {
-                datosPaciente = await pacienteCtrl.savePaciente(paciente, transaction);
+                await pacienteCtrl.savePaciente(paciente, transaction);
+                datosPaciente = await pacienteCtrl.getDatosPaciente('DNI', paciente, transaction);
             }
             await saveTurno(idAgendaAndes, turno, datosPaciente, bloque.duracionTurno, idTipoPrestacion, pool, transaction);
         }
@@ -30,7 +32,7 @@ export async function saveSobreturno(idAgendaAndes, sobreturno, idTipoPrestacion
         let result = await pacientes.buscarPaciente(sobreturno.paciente.id);
         let paciente = result.paciente;
 
-        let datosPaciente = await pacienteCtrl.getDatosPaciente('DNI', paciente.documento, pool);
+        let datosPaciente = await pacienteCtrl.getDatosPaciente('DNI', paciente, pool);
         if (!datosPaciente) {
             datosPaciente = await pacienteCtrl.savePaciente(paciente, transaction);
         }
@@ -167,7 +169,7 @@ async function updateTurno(id, estado, pool, transaction) {
         idEstado = 50; // Prestación ha sido liberada
     }
     let query = 'UPDATE dbo.Prestaciones_Worklist SET ' +
-        'idEstado=' + idEstado + ' where andesId=\'' + id + '\'' ;
+        'idEstado=' + idEstado + ' where andesId=\'' + id + '\'';
     return await new sql.Request(transaction)
         .query(query)
         .catch(err => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "API para ANDES",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION

### Requerimiento
* Actualización de versión v3.6.1

### Funcionalidad desarrollada 
1. Verificación del documento del paciente. Si le dieron un turno a un paciente temporal sin dni, se le asigna el objectId del paciente para guardarlo en la bd del HPN.
2. Si es una agenda 100% autocitada, se pone con estado publicada en Prestaciones 2.0
3. Se creo retry and fail. Si por algún motivo la transacción falla, prueba 2 veces más y cambia el estado a estadoIntegracion = Fail para evitar que se acumulen las agendas.




### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No


