### PR TITLE
PECAS- Control para turnos asignados

### DIFF
--- a/jobs/pecasConsolidadoJob.ts
+++ b/jobs/pecasConsolidadoJob.ts
@@ -2,8 +2,10 @@ import * as pecasCtrl from './../modules/estadistica/pecas/controller/agenda';
 import * as moment from 'moment';
 
 function run(done) {
-    let start = moment(new Date().setHours(0, 0, 0, 0)).subtract(1, 'day').format('YYYY-MM-DD HH:mm:ss');
-    let end = moment(new Date().setHours(23, 59, 0, 0)).subtract(1, 'day').format('YYYY-MM-DD HH:mm:ss');
+    // let start = moment(new Date().setHours(0, 0, 0, 0)).subtract(1, 'day').format('YYYY-MM-DD HH:mm:ss');
+    // let end = moment(new Date().setHours(23, 59, 0, 0)).subtract(1, 'day').format('YYYY-MM-DD HH:mm:ss');
+    let start = moment(new Date('2018-09-14T00:00:00.000-03:00')).format('YYYY-MM-DD HH:mm:ss');
+    let end = moment(new Date('2018-09-24T00:00:00.000-03:00')).format('YYYY-MM-DD HH:mm:ss');
     pecasCtrl.consultaPecas(start, end, done);
 }
 

--- a/jobs/pecasConsolidadoJob.ts
+++ b/jobs/pecasConsolidadoJob.ts
@@ -2,10 +2,8 @@ import * as pecasCtrl from './../modules/estadistica/pecas/controller/agenda';
 import * as moment from 'moment';
 
 function run(done) {
-    // let start = moment(new Date().setHours(0, 0, 0, 0)).subtract(1, 'day').format('YYYY-MM-DD HH:mm:ss');
-    // let end = moment(new Date().setHours(23, 59, 0, 0)).subtract(1, 'day').format('YYYY-MM-DD HH:mm:ss');
-    let start = moment(new Date('2018-09-14T00:00:00.000-03:00')).format('YYYY-MM-DD HH:mm:ss');
-    let end = moment(new Date('2018-09-24T00:00:00.000-03:00')).format('YYYY-MM-DD HH:mm:ss');
+    let start = moment(new Date().setHours(0, 0, 0, 0)).subtract(1, 'day').format('YYYY-MM-DD HH:mm:ss');
+    let end = moment(new Date().setHours(23, 59, 0, 0)).subtract(1, 'day').format('YYYY-MM-DD HH:mm:ss');
     pecasCtrl.consultaPecas(start, end, done);
 }
 

--- a/modules/estadistica/pecas/controller/agenda.ts
+++ b/modules/estadistica/pecas/controller/agenda.ts
@@ -6,6 +6,8 @@ import * as moment from 'moment';
 import { model as organizacion } from '../../../../core/tm/schemas/organizacion';
 import * as sql from 'mssql';
 import * as configPrivate from '../../../../config.private';
+import { Logger } from '../../../../utils/logService';
+import { userScheduler } from '../../../../config.private';
 
 let poolTurnos;
 const config = {
@@ -99,246 +101,246 @@ async function auxiliar(a: any, b: any, t: any) {
     let turno: any = {};
     turno.sobreturno = (b !== null) ? 'NO' : 'SI';
     // console.log('b => ', b);
-    turno.tipoTurno = t.tipoTurno ? (t.tipoTurno === 'profesional' ? 'autocitado' : (t.tipoTurno === 'gestion' ? 'conllave' : t.tipoTurno)) : 'Sin datos';
-    turno.estadoTurno = t.estado;
-    let turnoConPaciente = t.estado === 'asignado' && t.paciente && t.asistencia;
-    let efector = await getEfector(a.organizacion._id) as any;
-    let idEfector = efector ? efector.codigo : null;
-    let tipoEfector = efector ? efector.tipoEfector : null;
-    turno.tipoPrestacion = (turnoConPaciente && t.tipoPrestacion && t.tipoPrestacion.term) ? t.tipoPrestacion.term : null;
-    turno.idEfector = parseInt(idEfector, 10);
-    turno.Organizacion = a.organizacion.nombre;
-    turno.idAgenda = a._id;
-    turno.FechaAgenda = moment(a.horaInicio).format('YYYYMMDD');
-    turno.HoraAgenda = moment(a.horaInicio).format('HH:mm').toString();
-    turno.estadoAgenda = a.estado;
-    turno.numeroBloque = a.bloques.indexOf(b);
-    turno.accesoDirectoProgramado = (b && b.accesoDirectoProgramado) ? b.accesoDirectoProgramado : null;
-    turno.reservadoProfesional = (b && b.reservadoProfesional) ? b.reservadoProfesional : null;
-    turno.reservadoGestion = (b && b.reservadoGestion) ? b.reservadoGestion : null;
-    turno.accesoDirectoDelDia = (b && b.accesoDirectoDelDia) ? b.accesoDirectoDelDia : null;
-    turno.idTurno = String(t._id);
-    turno.FechaConsulta = moment(t.horaInicio).format('YYYYMMDD');
-    turno.HoraTurno = moment(t.horaInicio).format('HH:mm').toString();
-    turno.Periodo = parseInt(moment(t.horaInicio).format('YYYYMM').toString(), 10);
-    turno.DNI = turnoConPaciente ? Number(t.paciente.documento) : null;
-    turno.Apellido = turnoConPaciente ? t.paciente.apellido : null;
-    turno.Apellido = turnoConPaciente ? turno.Apellido.toString().replace('\'', '\'\'') : null;
-    turno.Nombres = turnoConPaciente ? t.paciente.nombre : null;
-    const carpetas = turnoConPaciente ? t.paciente.carpetaEfectores.filter(x => String(x.organizacion._id) === String(a.organizacion._id)) : [];
-    if (Array(carpetas).length > 0) {
-        turno.HC = carpetas[0] ? (carpetas[0] as any).nroCarpeta : null;
-    } else {
-        turno.HC = null;
-    }
-    turno.codSexo = turnoConPaciente ? String(t.paciente.sexo) === 'femenino' ? String(2) : String(1) : null;
-    turno.Sexo = turnoConPaciente ? t.paciente.sexo : null;
-    turno.FechaNacimiento = (turnoConPaciente && t.paciente.fechaNacimiento ? moment(t.paciente.fechaNacimiento).format('YYYYMMDD') : '');
-    const objectoEdad = (t.paciente && turno.FechaNacimiento) ? calcularEdad(t.paciente.fechaNacimiento) : null;
-
-    turno.Edad = t.paciente && turno.fechaNacimiento ? objectoEdad.valor : null;
-    turno.uniEdad = t.paciente && turno.fechaNacimiento ? objectoEdad.unidad : null;
-    turno.CodRangoEdad = t.paciente && turno.fechaNacimiento ? objectoEdad.CodRangoEdad : null;
-    turno.RangoEdad = t.paciente && turno.fechaNacimiento ? objectoEdad.RangoEdad : null;
-    turno.Peso = null;
-    turno.Talla = null;
-    turno.TAS = null;
-    turno.TAD = null;
-    turno.IMC = null;
-    turno.RCVG = null;
-    turno.codifica = null;
-    turno.Diag1CodigoOriginal = null;
-    turno.Desc1DiagOriginal = null;
-    turno.Diag1CodigoAuditado = null;
-    turno.Desc1DiagAuditado = null;
-    turno.conceptId1 = null;
-    turno.semanticTag1 = null;
-
-    turno.term1 = null;
-    turno.Principal = 0;
-    turno.Tipodeconsulta = null;
-    turno.ConsC2 = null;
-
-    // Estado turno
-    let estadoAuditoria = null;
-    if (t) {
-        // console.log(t.estado);
-        switch (t.estado) {
-            case 'disponible':
-                estadoAuditoria = 'Disponible';
-                break;
-            case 'suspendido':
-                estadoAuditoria = 'Suspendido';
-                break;
-            case 'asignado':
-                if (t.asistencia) {
-                    estadoAuditoria = 'Asistencia Verificada';
-                }
-                if (t.diagnostico.codificaciones.length > 0) {
-                    if (!(t.diagnostico.codificaciones[0].codificacionAuditoria && t.diagnostico.codificaciones[0].codificacionAuditoria.codigo) && (t.diagnostico.codificaciones[0].codificacionProfesional)) {
-                        estadoAuditoria = 'Registrado por Profesional';
-                    }
-                    if ((t.asistencia === 'noAsistio' || t.asistencia === 'sinDatos' || (t.diagnostico.codificaciones[0].codificacionAuditoria && t.diagnostico.codificaciones[0].codificacionAuditoria.codigo))) {
-                        estadoAuditoria = 'Auditado';
-                    }
-                }
-                break;
-            default:
-                estadoAuditoria = null;
-        }
-
-    }
-
-    turno.estadoTurnoAuditoria = estadoAuditoria;
-
-
-    // Asistencia
-    turno.asistencia = turnoConPaciente && t.asistencia ? t.asistencia : null;
-    turno.reasignado = turnoConPaciente && t.reasignado && t.reasignado.siguiente ? 'SI' : 'NO';
-    // Diagnóstico 1 ORIGINAL
-    if (t.diagnostico.codificaciones.length > 0 && t.diagnostico.codificaciones[0] && t.diagnostico.codificaciones[0].primeraVez !== undefined) {
-        turno.primeraVez1 = (t.diagnostico.codificaciones[0].primeraVez === true) ? 1 : 0;
-    } else {
-        turno.primeraVez1 = null;
-    }
-    if (t.diagnostico.codificaciones.length > 0 && t.diagnostico.codificaciones[0].codificacionProfesional) {
-        turno.codifica = 'PROFESIONAL';
-        if (t.diagnostico.codificaciones[0].codificacionProfesional.cie10 && t.diagnostico.codificaciones[0].codificacionProfesional.cie10.codigo) {
-            turno.Diag1CodigoOriginal = t.diagnostico.codificaciones[0].codificacionProfesional.cie10.codigo;
-            turno.Desc1DiagOriginal = t.diagnostico.codificaciones[0].codificacionProfesional.cie10.nombre;
-        }
-        if (t.diagnostico.codificaciones[0].codificacionProfesional.snomed && t.diagnostico.codificaciones[0].codificacionProfesional.snomed.conceptId) {
-            turno.conceptId1 = t.diagnostico.codificaciones[0].codificacionProfesional.snomed.conceptId;
-            turno.term1 = t.diagnostico.codificaciones[0].codificacionProfesional.snomed.term;
-            turno.semanticTag1 = t.diagnostico.codificaciones[0].codificacionProfesional.snomed.semanticTag;
-        }
-    } else {
-        turno.codifica = 'NO PROFESIONAL';
-    }
-    // Diagnóstico 1 AUDITADO
-    if (t.diagnostico.codificaciones.length > 0 && t.diagnostico.codificaciones[0].codificacionAuditoria && t.diagnostico.codificaciones[0].codificacionAuditoria.codigo) {
-        turno.Diag1CodigoAuditado = t.diagnostico.codificaciones[0].codificacionAuditoria.codigo;
-        turno.Desc1DiagAuditado = t.diagnostico.codificaciones[0].codificacionAuditoria.nombre;
-        turno.ConsC2 = t.diagnostico.codificaciones[0].codificacionAuditoria.c2 && t.diagnostico.codificaciones[0].primeraVez ? 'SI' : 'NO';
-        turno.Tipodeconsulta = t.diagnostico.codificaciones[0].primeraVez ? 'Primera vez' : 'Ulterior';
-        turno.Principal = 1;
-    }
-
-    // Diagnóstico 2 ORIGINAL
-    turno.Diag2CodigoOriginal = null;
-    turno.Desc2DiagOriginal = null;
-    turno.Diag2CodigoAuditado = null;
-    turno.Desc2DiagAuditado = null;
-    turno.conceptId2 = null;
-    turno.term2 = null;
-    turno.semanticTag2 = null;
-    if (t.diagnostico.codificaciones.length > 1 && t.diagnostico.codificaciones[1] && t.diagnostico.codificaciones[1].primeraVez !== undefined) {
-        turno.primeraVez2 = (t.diagnostico.codificaciones[1].primeraVez === true) ? 1 : 0;
-    } else {
-        turno.primeraVez2 = null;
-    }
-    if (t.diagnostico.codificaciones.length > 1 && t.diagnostico.codificaciones[1].codificacionProfesional) {
-        if (t.diagnostico.codificaciones[1].codificacionProfesional.cie10 && t.diagnostico.codificaciones[1].codificacionProfesional.cie10.codigo) {
-            turno.Diag2CodigoOriginal = t.diagnostico.codificaciones[1].codificacionProfesional.cie10.codigo;
-            turno.Desc2DiagOriginal = t.diagnostico.codificaciones[1].codificacionProfesional.cie10.nombre;
-        }
-        if (t.diagnostico.codificaciones[1].codificacionProfesional.snomed && t.diagnostico.codificaciones[1].codificacionProfesional.snomed.conceptId) {
-            turno.conceptId2 = t.diagnostico.codificaciones[1].codificacionProfesional.snomed.conceptId;
-            turno.term2 = t.diagnostico.codificaciones[1].codificacionProfesional.snomed.term;
-            turno.semanticTag2 = t.diagnostico.codificaciones[1].codificacionProfesional.snomed.semanticTag;
-        }
-    }
-    // Diagnóstico 2 AUDITADO
-    if (t.diagnostico.codificaciones.length > 1 && t.diagnostico.codificaciones[1].codificacionAuditoria && t.diagnostico.codificaciones[1].codificacionAuditoria.codigo) {
-        turno.Diag2CodigoAuditado = t.diagnostico.codificaciones[1].codificacionAuditoria.codigo;
-        turno.Desc2DiagAuditado = t.diagnostico.codificaciones[1].codificacionAuditoria.nombre;
-    }
-    // Diagnóstico 3 ORIGINAL
-    turno.Diag3CodigoOriginal = null;
-    turno.Desc3DiagOriginal = null;
-    turno.Diag3CodigoAuditado = null;
-    turno.Desc3DiagAuditado = null;
-    turno.conceptId3 = null;
-    turno.term3 = null;
-    turno.semanticTag3 = null;
-
-    if (t.diagnostico.codificaciones.length > 2 && t.diagnostico.codificaciones[2] && t.diagnostico.codificaciones[2].primeraVez !== undefined) {
-        turno.primeraVez3 = (t.diagnostico.codificaciones[2].primeraVez === true) ? 1 : 0;
-    } else {
-        turno.primeraVez3 = null;
-    }
-    if (t.diagnostico.codificaciones.length > 2 && t.diagnostico.codificaciones[2].codificacionProfesional) {
-        if (t.diagnostico.codificaciones[2].codificacionProfesional.cie10 && t.diagnostico.codificaciones[2].codificacionProfesional.cie10.codigo) {
-            turno.Diag3CodigoOriginal = t.diagnostico.codificaciones[2].codificacionProfesional.cie10.codigo;
-            turno.Desc3DiagOriginal = t.diagnostico.codificaciones[2].codificacionProfesional.cie10.nombre;
-        }
-        if (t.diagnostico.codificaciones[2].codificacionProfesional.snomed && t.diagnostico.codificaciones[2].codificacionProfesional.snomed.conceptId) {
-            turno.conceptId3 = t.diagnostico.codificaciones[2].codificacionProfesional.snomed.conceptId;
-            turno.term3 = t.diagnostico.codificaciones[2].codificacionProfesional.snomed.term;
-            turno.semanticTag3 = t.diagnostico.codificaciones[2].codificacionProfesional.snomed.semanticTag;
-        }
-    }
-    // Diagnóstico 3 AUDITADO
-    if (t.diagnostico.codificaciones.length > 2 && t.diagnostico.codificaciones[2].codificacionAuditoria && t.diagnostico.codificaciones[2].codificacionAuditoria.codigo) {
-        turno.Diag3CodigoAuditado = t.diagnostico.codificaciones[2].codificacionAuditoria.codigo;
-        turno.Desc3DiagAuditado = t.diagnostico.codificaciones[2].codificacionAuditoria.nombre;
-    }
-
-    turno.Profesional = (a.profesionales && a.profesionales[0] && a.profesionales.length > 0 ? a.profesionales.map(pr => String(pr.apellido) + ', ' + String(pr.nombre)).join('; ') : 'Sin profesionales');
-    turno.Profesional = turno.Profesional.toString().replace('\'', '\'\'');
-    turno.TipoProfesional = null;
-    turno.CodigoEspecialidad = null;
-    turno.Especialidad = null;
-    turno.CodigoServicio = null;
-    turno.Servicio = (a.espacioFisico && a.espacioFisico.servicio ? a.espacioFisico.servicio.nombre : 'Sin servicio');
-    turno.IdBarrio = null;
-    turno.Barrio = null;
-    turno.IdLocalidad = null;
-    turno.Localidad = null;
-    turno.IdDpto = null;
-    turno.Departamento = null;
-    turno.IdPcia = null;
-    turno.Provincia = null;
-    turno.IdNacionalidad = null;
-    turno.Nacionalidad = null;
-    turno.Calle = null;
-    turno.Altura = null;
-    turno.Piso = null;
-    turno.Depto = null;
-    turno.Manzana = null;
-    turno.ConsObst = t.tipoPrestacion && t.tipoPrestacion.term.includes('obstetricia') ? 'SI' : 'NO';
-    turno.IdObraSocial = (turnoConPaciente && t.paciente.obraSocial && t.paciente.obraSocial.codigo) ? t.paciente.obraSocial.codigo : null;
-    turno.ObraSocial = (turnoConPaciente && t.paciente.obraSocial && t.paciente.obraSocial.nombre) ? t.paciente.obraSocial.nombre.toString().replace('\'', '\'\'') : null;
-    if (tipoEfector && tipoEfector === 'Centro de Salud') {
-        turno.TipoEfector = '1';
-    }
-    if (tipoEfector && tipoEfector === 'Hospital') {
-        turno.TipoEfector = '2';
-    }
-    if (tipoEfector && tipoEfector === 'Puesto Sanitario') {
-        turno.TipoEfector = '3';
-    }
-    if (tipoEfector && tipoEfector === 'ONG') {
-        turno.TipoEfector = '6';
-    }
-    turno.DescTipoEfector = tipoEfector;
-    turno.IdZona = null;
-    turno.Zona = null;
-    turno.SubZona = null;
-    turno.idEfectorSuperior = null;
-    turno.EfectorSuperior = null;
-    turno.AreaPrograma = null;
-
-    turno.IdPaciente = (t.paciente) ? String(t.paciente.id) : null;
-    turno.Longitud = '';
-    turno.Latitud = '';
-    turno.telefono = t.paciente && t.paciente.telefono ? t.paciente.telefono : '';
-    turno.estadoAgenda = a.estado;
     try {
         // Chequear si el turno existe en sql PECAS y depeniendo de eso hacer un insert o  un update
+        turno.tipoTurno = t.tipoTurno ? (t.tipoTurno === 'profesional' ? 'autocitado' : (t.tipoTurno === 'gestion' ? 'conllave' : t.tipoTurno)) : 'Sin datos';
+        turno.estadoTurno = t.estado;
+        let turnoConPaciente = t.estado === 'asignado' && t.paciente; // && t.asistencia
+        let efector = await getEfector(a.organizacion._id) as any;
+        let idEfector = efector ? efector.codigo : null;
+        let tipoEfector = efector ? efector.tipoEfector : null;
+        turno.tipoPrestacion = (turnoConPaciente && t.tipoPrestacion && t.tipoPrestacion.term) ? t.tipoPrestacion.term : null;
+        turno.idEfector = parseInt(idEfector, 10);
+        turno.Organizacion = a.organizacion.nombre;
+        turno.idAgenda = a._id;
+        turno.FechaAgenda = moment(a.horaInicio).format('YYYYMMDD');
+        turno.HoraAgenda = moment(a.horaInicio).format('HH:mm').toString();
+        turno.estadoAgenda = a.estado;
+        turno.numeroBloque = a.bloques.indexOf(b);
+        turno.accesoDirectoProgramado = (b && b.accesoDirectoProgramado) ? b.accesoDirectoProgramado : null;
+        turno.reservadoProfesional = (b && b.reservadoProfesional) ? b.reservadoProfesional : null;
+        turno.reservadoGestion = (b && b.reservadoGestion) ? b.reservadoGestion : null;
+        turno.accesoDirectoDelDia = (b && b.accesoDirectoDelDia) ? b.accesoDirectoDelDia : null;
+        turno.idTurno = String(t._id);
+        turno.FechaConsulta = moment(t.horaInicio).format('YYYYMMDD');
+        turno.HoraTurno = moment(t.horaInicio).format('HH:mm').toString();
+        turno.Periodo = parseInt(moment(t.horaInicio).format('YYYYMM').toString(), 10);
+        turno.DNI = turnoConPaciente ? Number(t.paciente.documento) : null;
+        turno.Apellido = turnoConPaciente ? t.paciente.apellido : null;
+        turno.Apellido = turnoConPaciente ? turno.Apellido.toString().replace('\'', '\'\'') : null;
+        turno.Nombres = turnoConPaciente ? t.paciente.nombre : null;
+        const carpetas = turnoConPaciente ? t.paciente.carpetaEfectores.filter(x => String(x.organizacion._id) === String(a.organizacion._id)) : [];
+        if (Array(carpetas).length > 0) {
+            turno.HC = carpetas[0] ? (carpetas[0] as any).nroCarpeta : null;
+        } else {
+            turno.HC = null;
+        }
+        turno.codSexo = turnoConPaciente ? String(t.paciente.sexo) === 'femenino' ? String(2) : String(1) : null;
+        turno.Sexo = turnoConPaciente ? t.paciente.sexo : null;
+        turno.FechaNacimiento = (turnoConPaciente && t.paciente.fechaNacimiento ? moment(t.paciente.fechaNacimiento).format('YYYYMMDD') : '');
+        const objectoEdad = (t.paciente && turno.FechaNacimiento) ? calcularEdad(t.paciente.fechaNacimiento) : null;
+
+        turno.Edad = t.paciente && turno.fechaNacimiento ? objectoEdad.valor : null;
+        turno.uniEdad = t.paciente && turno.fechaNacimiento ? objectoEdad.unidad : null;
+        turno.CodRangoEdad = t.paciente && turno.fechaNacimiento ? objectoEdad.CodRangoEdad : null;
+        turno.RangoEdad = t.paciente && turno.fechaNacimiento ? objectoEdad.RangoEdad : null;
+        turno.Peso = null;
+        turno.Talla = null;
+        turno.TAS = null;
+        turno.TAD = null;
+        turno.IMC = null;
+        turno.RCVG = null;
+        turno.codifica = null;
+        turno.Diag1CodigoOriginal = null;
+        turno.Desc1DiagOriginal = null;
+        turno.Diag1CodigoAuditado = null;
+        turno.Desc1DiagAuditado = null;
+        turno.conceptId1 = null;
+        turno.semanticTag1 = null;
+
+        turno.term1 = null;
+        turno.Principal = 0;
+        turno.Tipodeconsulta = null;
+        turno.ConsC2 = null;
+
+        // Estado turno
+        let estadoAuditoria = null;
+        if (t) {
+            // console.log(t.estado);
+            switch (t.estado) {
+                case 'disponible':
+                    estadoAuditoria = 'Disponible';
+                    break;
+                case 'suspendido':
+                    estadoAuditoria = 'Suspendido';
+                    break;
+                case 'asignado':
+                    if (t.asistencia) {
+                        estadoAuditoria = 'Asistencia Verificada';
+                    }
+                    if (t.diagnostico.codificaciones.length > 0) {
+                        if (!(t.diagnostico.codificaciones[0].codificacionAuditoria && t.diagnostico.codificaciones[0].codificacionAuditoria.codigo) && (t.diagnostico.codificaciones[0].codificacionProfesional)) {
+                            estadoAuditoria = 'Registrado por Profesional';
+                        }
+                        if ((t.asistencia === 'noAsistio' || t.asistencia === 'sinDatos' || (t.diagnostico.codificaciones[0].codificacionAuditoria && t.diagnostico.codificaciones[0].codificacionAuditoria.codigo))) {
+                            estadoAuditoria = 'Auditado';
+                        }
+                    }
+                    break;
+                default:
+                    estadoAuditoria = null;
+            }
+
+        }
+
+        turno.estadoTurnoAuditoria = estadoAuditoria;
+
+
+        // Asistencia
+        turno.asistencia = turnoConPaciente && t.asistencia ? t.asistencia : null;
+        turno.reasignado = turnoConPaciente && t.reasignado && t.reasignado.siguiente ? 'SI' : 'NO';
+        // Diagnóstico 1 ORIGINAL
+        if (t.diagnostico.codificaciones.length > 0 && t.diagnostico.codificaciones[0] && t.diagnostico.codificaciones[0].primeraVez !== undefined) {
+            turno.primeraVez1 = (t.diagnostico.codificaciones[0].primeraVez === true) ? 1 : 0;
+        } else {
+            turno.primeraVez1 = null;
+        }
+        if (t.diagnostico.codificaciones.length > 0 && t.diagnostico.codificaciones[0].codificacionProfesional) {
+            turno.codifica = 'PROFESIONAL';
+            if (t.diagnostico.codificaciones[0].codificacionProfesional.cie10 && t.diagnostico.codificaciones[0].codificacionProfesional.cie10.codigo) {
+                turno.Diag1CodigoOriginal = t.diagnostico.codificaciones[0].codificacionProfesional.cie10.codigo;
+                turno.Desc1DiagOriginal = t.diagnostico.codificaciones[0].codificacionProfesional.cie10.nombre;
+            }
+            if (t.diagnostico.codificaciones[0].codificacionProfesional.snomed && t.diagnostico.codificaciones[0].codificacionProfesional.snomed.conceptId) {
+                turno.conceptId1 = t.diagnostico.codificaciones[0].codificacionProfesional.snomed.conceptId;
+                turno.term1 = t.diagnostico.codificaciones[0].codificacionProfesional.snomed.term;
+                turno.semanticTag1 = t.diagnostico.codificaciones[0].codificacionProfesional.snomed.semanticTag;
+            }
+        } else {
+            turno.codifica = 'NO PROFESIONAL';
+        }
+        // Diagnóstico 1 AUDITADO
+        if (t.diagnostico.codificaciones.length > 0 && t.diagnostico.codificaciones[0].codificacionAuditoria && t.diagnostico.codificaciones[0].codificacionAuditoria.codigo) {
+            turno.Diag1CodigoAuditado = t.diagnostico.codificaciones[0].codificacionAuditoria.codigo;
+            turno.Desc1DiagAuditado = t.diagnostico.codificaciones[0].codificacionAuditoria.nombre;
+            turno.ConsC2 = t.diagnostico.codificaciones[0].codificacionAuditoria.c2 && t.diagnostico.codificaciones[0].primeraVez ? 'SI' : 'NO';
+            turno.Tipodeconsulta = t.diagnostico.codificaciones[0].primeraVez ? 'Primera vez' : 'Ulterior';
+            turno.Principal = 1;
+        }
+
+        // Diagnóstico 2 ORIGINAL
+        turno.Diag2CodigoOriginal = null;
+        turno.Desc2DiagOriginal = null;
+        turno.Diag2CodigoAuditado = null;
+        turno.Desc2DiagAuditado = null;
+        turno.conceptId2 = null;
+        turno.term2 = null;
+        turno.semanticTag2 = null;
+        if (t.diagnostico.codificaciones.length > 1 && t.diagnostico.codificaciones[1] && t.diagnostico.codificaciones[1].primeraVez !== undefined) {
+            turno.primeraVez2 = (t.diagnostico.codificaciones[1].primeraVez === true) ? 1 : 0;
+        } else {
+            turno.primeraVez2 = null;
+        }
+        if (t.diagnostico.codificaciones.length > 1 && t.diagnostico.codificaciones[1].codificacionProfesional) {
+            if (t.diagnostico.codificaciones[1].codificacionProfesional.cie10 && t.diagnostico.codificaciones[1].codificacionProfesional.cie10.codigo) {
+                turno.Diag2CodigoOriginal = t.diagnostico.codificaciones[1].codificacionProfesional.cie10.codigo;
+                turno.Desc2DiagOriginal = t.diagnostico.codificaciones[1].codificacionProfesional.cie10.nombre;
+            }
+            if (t.diagnostico.codificaciones[1].codificacionProfesional.snomed && t.diagnostico.codificaciones[1].codificacionProfesional.snomed.conceptId) {
+                turno.conceptId2 = t.diagnostico.codificaciones[1].codificacionProfesional.snomed.conceptId;
+                turno.term2 = t.diagnostico.codificaciones[1].codificacionProfesional.snomed.term;
+                turno.semanticTag2 = t.diagnostico.codificaciones[1].codificacionProfesional.snomed.semanticTag;
+            }
+        }
+        // Diagnóstico 2 AUDITADO
+        if (t.diagnostico.codificaciones.length > 1 && t.diagnostico.codificaciones[1].codificacionAuditoria && t.diagnostico.codificaciones[1].codificacionAuditoria.codigo) {
+            turno.Diag2CodigoAuditado = t.diagnostico.codificaciones[1].codificacionAuditoria.codigo;
+            turno.Desc2DiagAuditado = t.diagnostico.codificaciones[1].codificacionAuditoria.nombre;
+        }
+        // Diagnóstico 3 ORIGINAL
+        turno.Diag3CodigoOriginal = null;
+        turno.Desc3DiagOriginal = null;
+        turno.Diag3CodigoAuditado = null;
+        turno.Desc3DiagAuditado = null;
+        turno.conceptId3 = null;
+        turno.term3 = null;
+        turno.semanticTag3 = null;
+
+        if (t.diagnostico.codificaciones.length > 2 && t.diagnostico.codificaciones[2] && t.diagnostico.codificaciones[2].primeraVez !== undefined) {
+            turno.primeraVez3 = (t.diagnostico.codificaciones[2].primeraVez === true) ? 1 : 0;
+        } else {
+            turno.primeraVez3 = null;
+        }
+        if (t.diagnostico.codificaciones.length > 2 && t.diagnostico.codificaciones[2].codificacionProfesional) {
+            if (t.diagnostico.codificaciones[2].codificacionProfesional.cie10 && t.diagnostico.codificaciones[2].codificacionProfesional.cie10.codigo) {
+                turno.Diag3CodigoOriginal = t.diagnostico.codificaciones[2].codificacionProfesional.cie10.codigo;
+                turno.Desc3DiagOriginal = t.diagnostico.codificaciones[2].codificacionProfesional.cie10.nombre;
+            }
+            if (t.diagnostico.codificaciones[2].codificacionProfesional.snomed && t.diagnostico.codificaciones[2].codificacionProfesional.snomed.conceptId) {
+                turno.conceptId3 = t.diagnostico.codificaciones[2].codificacionProfesional.snomed.conceptId;
+                turno.term3 = t.diagnostico.codificaciones[2].codificacionProfesional.snomed.term;
+                turno.semanticTag3 = t.diagnostico.codificaciones[2].codificacionProfesional.snomed.semanticTag;
+            }
+        }
+        // Diagnóstico 3 AUDITADO
+        if (t.diagnostico.codificaciones.length > 2 && t.diagnostico.codificaciones[2].codificacionAuditoria && t.diagnostico.codificaciones[2].codificacionAuditoria.codigo) {
+            turno.Diag3CodigoAuditado = t.diagnostico.codificaciones[2].codificacionAuditoria.codigo;
+            turno.Desc3DiagAuditado = t.diagnostico.codificaciones[2].codificacionAuditoria.nombre;
+        }
+
+        turno.Profesional = (a.profesionales && a.profesionales[0] && a.profesionales.length > 0 ? a.profesionales.map(pr => String(pr.apellido) + ', ' + String(pr.nombre)).join('; ') : 'Sin profesionales');
+        turno.Profesional = turno.Profesional.toString().replace('\'', '\'\'');
+        turno.TipoProfesional = null;
+        turno.CodigoEspecialidad = null;
+        turno.Especialidad = null;
+        turno.CodigoServicio = null;
+        turno.Servicio = (a.espacioFisico && a.espacioFisico.servicio ? a.espacioFisico.servicio.nombre : 'Sin servicio');
+        turno.IdBarrio = null;
+        turno.Barrio = null;
+        turno.IdLocalidad = null;
+        turno.Localidad = null;
+        turno.IdDpto = null;
+        turno.Departamento = null;
+        turno.IdPcia = null;
+        turno.Provincia = null;
+        turno.IdNacionalidad = null;
+        turno.Nacionalidad = null;
+        turno.Calle = null;
+        turno.Altura = null;
+        turno.Piso = null;
+        turno.Depto = null;
+        turno.Manzana = null;
+        turno.ConsObst = t.tipoPrestacion && t.tipoPrestacion.term.includes('obstetricia') ? 'SI' : 'NO';
+        turno.IdObraSocial = (turnoConPaciente && t.paciente.obraSocial && t.paciente.obraSocial.codigo) ? t.paciente.obraSocial.codigo : null;
+        turno.ObraSocial = (turnoConPaciente && t.paciente.obraSocial && t.paciente.obraSocial.nombre) ? t.paciente.obraSocial.nombre.toString().replace('\'', '\'\'') : null;
+        if (tipoEfector && tipoEfector === 'Centro de Salud') {
+            turno.TipoEfector = '1';
+        }
+        if (tipoEfector && tipoEfector === 'Hospital') {
+            turno.TipoEfector = '2';
+        }
+        if (tipoEfector && tipoEfector === 'Puesto Sanitario') {
+            turno.TipoEfector = '3';
+        }
+        if (tipoEfector && tipoEfector === 'ONG') {
+            turno.TipoEfector = '6';
+        }
+        turno.DescTipoEfector = tipoEfector;
+        turno.IdZona = null;
+        turno.Zona = null;
+        turno.SubZona = null;
+        turno.idEfectorSuperior = null;
+        turno.EfectorSuperior = null;
+        turno.AreaPrograma = null;
+
+        turno.IdPaciente = (t.paciente) ? String(t.paciente.id) : null;
+        turno.Longitud = '';
+        turno.Latitud = '';
+        turno.telefono = t.paciente && t.paciente.telefono ? t.paciente.telefono : '';
+        turno.estadoAgenda = a.estado;
 
         // se verifica si existe el turno en sql
-        let queryInsert = 'INSERT INTO dbo.Pecas_test' +
+        let queryInsert = 'INSERT INTO dbo.Pecas_consolidado_2' +
             '(idEfector, Efector, TipoEfector, DescTipoEfector, IdZona, Zona, SubZona, idEfectorSuperior, EfectorSuperior, AreaPrograma, ' +
             'idAgenda, FechaAgenda, HoraAgenda, estadoAgenda, numeroBloque, turnosProgramados, turnosProfesional, turnosLlaves, turnosDelDia, ' +
             'idTurno, estadoTurno, tipoTurno, sobreturno, FechaConsulta, HoraTurno, Periodo, Tipodeconsulta, estadoTurnoAuditoria, Principal, ConsC2, ConsObst, tipoPrestacion, ' +
@@ -394,14 +396,14 @@ async function auxiliar(a: any, b: any, t: any) {
 async function existeTurnoPecas(turno: any) {
     const result = await new sql.Request(poolTurnos)
         .input('idTurno', sql.VarChar(50), turno)
-        .query('SELECT idTurno FROM dbo.Pecas_test WHERE idTurno = @idTurno');
+        .query('SELECT idTurno FROM dbo.Pecas_consolidado_2 WHERE idTurno = @idTurno');
     return result;
 }
 
 async function eliminaTurnoPecas(turno: any) {
     const result = await new sql.Request(poolTurnos)
         .input('idTurno', sql.VarChar(50), turno)
-        .query('DELETE FROM dbo.Pecas_test WHERE idTurno = @idTurno');
+        .query('DELETE FROM dbo.Pecas_consolidado_2 WHERE idTurno = @idTurno');
     return result;
 }
 
@@ -518,9 +520,10 @@ async function executeQuery(query: any) {
         }
     } catch (err) {
         // console.log('err ', err);
-        let jsonWrite = fs.appendFileSync(outputFile, query + '\r', {
-            encoding: 'utf8'
-        });
+        // let jsonWrite = fs.appendFileSync(outputFile, query + '\r', {
+        //     encoding: 'utf8'
+        // });
+        Logger.log(userScheduler, 'scheduler', 'insert', query);
         return err;
     }
 }


### PR DESCRIPTION
### Funcionalidad desarrollada 
1. Agrega control para los turnos que tienen un paciente asignado pero sin asistencia verificada
2. Se agrega en el logs las query que no se pudieron ejecutar en el proceso de PECAS


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] Se reportó personalmente 

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
