### PR TITLE
Publicar la ruta de padrones de obra social

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -145,7 +145,7 @@ export const modules = {
         active: true,
         path: './modules/obraSocial/routes',
         route: '/modules/obraSocial',
-        middleware: appMiddleware
+        middleware: null // appMiddleware
     },
     sugerencias: {
         active: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "description": "API para ANDES",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
### Requerimiento
* Publicar la ruta de padrones para que se pueda acceder desde diferentes efectores de la provincia

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se quita la autenticación a la ruta de puco.


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

