### PR TITLE
Documentación: cambia ubicación de swagger.json

### DIFF
--- a/swagger/static/index.html
+++ b/swagger/static/index.html
@@ -74,7 +74,7 @@
 
       // Build a system
       const ui = SwaggerUIBundle({
-        url: "/swagger.json ",
+        url: "/api/swagger.json ",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/swagger/swagger.class.ts
+++ b/swagger/swagger.class.ts
@@ -49,7 +49,7 @@ export class Swagger {
         });
 
         // serve swagger
-        app.get('/swagger.json', (req, res) => {
+        app.get('/api/swagger.json', (req, res) => {
             res.setHeader('Content-Type', 'application/json');
             res.send(swagger);
         });


### PR DESCRIPTION
### Funcionalidad desarrollada 
1. Cambiar la URL del archivo swagger.json. Se mueve a '/api/swagger.json'.

