### PR TITLE
Se agrega prestacion generica de consulta

### DIFF
--- a/modules/cda/controller/CDAPatient.ts
+++ b/modules/cda/controller/CDAPatient.ts
@@ -114,7 +114,21 @@ export async function matchCode(snomed) {
         if (prestacion) {
             return prestacion;
         } else {
-            return null;
+            // Devuelvo una prestación genérica debido a que no existe el mapeo aún
+            return prestacion = {
+                loinc: {
+                    code: '34764-1',
+                    codeSystem: '2.16.840.1.113883.6.1',
+                    codeSystemName: 'LOINC',
+                    displayName: 'General medicine Consult note'
+                },
+                snomed: {
+                    conceptId: '11429006',
+                    term: 'consulta (procedimiento)',
+                    fsn: 'consulta (procedimiento)',
+                    semanticTag: 'procedimiento'
+                }
+            };
         }
     } else {
         return null;


### PR DESCRIPTION

CDA: Se crea una prestación genérica cuando no matchea con ninguna prestación de la colección configuración prestaciones. Para evitar que falle por falta de codificación.

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No
