### PR TITLE
mpi: implementa paquete request en google maps

### DIFF
--- a/core/mpi/controller/paciente.ts
+++ b/core/mpi/controller/paciente.ts
@@ -14,6 +14,7 @@ const regtest = /[^a-zA-Zàáâäãåąčćęèéêëėįìíîïłńòóôöõ�
 import * as https from 'https';
 import * as configPrivate from '../../../config.private';
 import { getServicioGeonode } from '../../../utils/servicioGeonode';
+import { handleHttpRequest } from '../../../utils/requestHandler';
 
 /**
  * Crea un paciente y lo sincroniza con elastic
@@ -815,44 +816,24 @@ export async function actualizarGeoReferencia(req, data) {
     }
 }
 
-export function geoRefPaciente(dataPaciente) {
-    return new Promise((resolve, reject) => {
-        const address = dataPaciente.direccion[0].valor + ',' + dataPaciente.direccion[0].ubicacion.localidad.nombre;
-        let pathGoogleApi = '';
-        let jsonGoogle = '';
+export async function geoRefPaciente(dataPaciente) {
+    const address = dataPaciente.direccion[0].valor + ',' + dataPaciente.direccion[0].ubicacion.localidad.nombre;
+    let pathGoogleApi = 'https://maps.googleapis.com/maps/api/geocode/json?address=' + address + ', ' + 'AR' + '&key=' + configPrivate.geoKey;
 
-        pathGoogleApi = '/maps/api/geocode/json?address=' + address + ', ' + 'AR' + '&key=' + configPrivate.geoKey;
+    pathGoogleApi = pathGoogleApi.replace(/ /g, '+');
+    pathGoogleApi = pathGoogleApi.replace(/á/gi, 'a');
+    pathGoogleApi = pathGoogleApi.replace(/é/gi, 'e');
+    pathGoogleApi = pathGoogleApi.replace(/í/gi, 'i');
+    pathGoogleApi = pathGoogleApi.replace(/ó/gi, 'o');
+    pathGoogleApi = pathGoogleApi.replace(/ú/gi, 'u');
+    pathGoogleApi = pathGoogleApi.replace(/ü/gi, 'u');
+    pathGoogleApi = pathGoogleApi.replace(/ñ/gi, 'n');
 
-        pathGoogleApi = pathGoogleApi.replace(/ /g, '+');
-        pathGoogleApi = pathGoogleApi.replace(/á/gi, 'a');
-        pathGoogleApi = pathGoogleApi.replace(/é/gi, 'e');
-        pathGoogleApi = pathGoogleApi.replace(/í/gi, 'i');
-        pathGoogleApi = pathGoogleApi.replace(/ó/gi, 'o');
-        pathGoogleApi = pathGoogleApi.replace(/ú/gi, 'u');
-        pathGoogleApi = pathGoogleApi.replace(/ü/gi, 'u');
-        pathGoogleApi = pathGoogleApi.replace(/ñ/gi, 'n');
-
-        const optionsgetmsg = {
-            host: 'maps.googleapis.com',
-            port: 443,
-            path: pathGoogleApi,
-            method: 'GET',
-            rejectUnauthorized: false
-        };
-        const reqGet = https.request(optionsgetmsg, (res2) => {
-            res2.on('data', (d, error) => {
-                jsonGoogle = jsonGoogle + d.toString();
-            });
-            res2.on('end', () => {
-                const salida = JSON.parse(jsonGoogle);
-                if (salida.status === 'OK') {
-                    return resolve(salida.results[0].geometry.location);
-                } else {
-                    return resolve({});
-                }
-            });
-        });
-        reqGet.end();
-    });
+    const [status, body] = await handleHttpRequest(pathGoogleApi);
+    const salida = JSON.parse(body);
+    if (salida.status === 'OK') {
+        return salida.results[0].geometry.location;
+    } else {
+        return {};
+    }
 }
-


### PR DESCRIPTION
### Funcionalidad desarrollada 
1. Adapta consulta a Google maps al paquete 'request' porque utiliza internamente el proxy.

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No
