### PR TITLE
Formatea las fechas en noticias de punto saludable

### DIFF
--- a/modules/mobileApp/auth_routes/noticias.ts
+++ b/modules/mobileApp/auth_routes/noticias.ts
@@ -25,7 +25,7 @@ router.get('/noticias/:name', async (req, res) => {
                     }
                     const tw = {
                         id: item.id_str,
-                        fecha: moment(item.created_at, 'ddd MMM DD HH:mm:ss ZZ YYYY'),
+                        fecha: moment(item.created_at, 'ddd MMM DD HH:mm:ss ZZ YYYY', 'en'),
                         text,
                         hashtags: item.entities.hashtags ? item.entities.hashtags.map(i => i.text) : [],
                         urls: item.entities.urls ? item.entities.urls.map(i => i.expanded_url) : [],


### PR DESCRIPTION
### Requerimiento
* Resuelve incidente en las noticias de punto saludable. Las fechas de las noticias se visualizaban diferentes a las fechas de las publicaciones realizadas en el sitio de twitter.

### Funcionalidad desarrollada 
1. Se especifica un argumento más en la conversión de las fechas con moment, ya que el lenguaje es "en", y estaba tomando el lenguaje por defecto.

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No



