### PR TITLE
CITAS - verificar estados en agendas pasadas

### DIFF
--- a/jobs/actualizarAgendasJob.ts
+++ b/jobs/actualizarAgendasJob.ts
@@ -1,9 +1,13 @@
 import * as agendaCtrl from './../modules/turnos/controller/agenda';
+import moment = require('moment');
 
 function run(done) {
+    const fechaActualizar = moment(new Date());
+    const start = (moment(fechaActualizar).startOf('day').subtract(1, 'days').toDate() as any);
+    const end = (moment(fechaActualizar).endOf('day').toDate() as any);
     Promise.all([
         agendaCtrl.actualizarTiposDeTurno(),
-        agendaCtrl.actualizarEstadoAgendas()
+        agendaCtrl.actualizarEstadoAgendas(start, end)
     ]).then(done).catch(done);
 }
 

--- a/jobs/actualizarEstadosAgenda.ts
+++ b/jobs/actualizarEstadosAgenda.ts
@@ -7,7 +7,8 @@ async function run(done) {
 
     const start = (moment(fechaDesde).startOf('day')).format('YYYY-MM-DD HH:mm:ss');
     const end = (moment(fechaHAsta).endOf('day')).format('YYYY-MM-DD HH:mm:ss');
-    agendaCtrl.actualizarEstadoAgendas(start, end);
+    agendaCtrl.actualizarEstadoAgendas(start, end).then(done)
+        .catch(done);
 }
 
 export = run;

--- a/jobs/actualizarEstadosAgenda.ts
+++ b/jobs/actualizarEstadosAgenda.ts
@@ -1,0 +1,13 @@
+import * as agendaCtrl from '../modules/turnos/controller/agenda';
+import moment = require('moment');
+
+async function run(done) {
+    const fechaDesde = moment(new Date(2018, 11, 1)); // mes - 1
+    const fechaHAsta = moment(new Date(2018, 11, 31)); // mes - 1
+
+    const start = (moment(fechaDesde).startOf('day')).format('YYYY-MM-DD HH:mm:ss');
+    const end = (moment(fechaHAsta).endOf('day')).format('YYYY-MM-DD HH:mm:ss');
+    agendaCtrl.actualizarEstadoAgendas(start, end);
+}
+
+export = run;

--- a/modules/rup/routes/codificacion.ts
+++ b/modules/rup/routes/codificacion.ts
@@ -50,8 +50,7 @@ router.get('/codificacion/:id?', async (req, res, next) => {
         const unaCodificacion = await codificacion.findById(req.params.id);
         res.json(unaCodificacion);
     } else {
-        let query;
-        query = codificacion.find({});
+        let query = codificacion.find({});
         if (req.query.fechaDesde) {
             query.where('createdAt').gte(req.query.fechaDesde);
         }

--- a/modules/turnos/controller/agenda.ts
+++ b/modules/turnos/controller/agenda.ts
@@ -770,56 +770,63 @@ export async function actualizarTiposDeTurno() {
  * Pendiente Auditoría según corresponda
  * se ejecuta una vez al día por el scheduler.
  *
- * @export actualizarTiposDeTurno()
+ * @export actualizarEstadoAgendas()
+ * @param {any} start
+ * @param {any} end
  * @returns resultado
  */
-export function actualizarEstadoAgendas() {
-    // let fechaActualizar = moment(new Date()).subtract(1, 'days');
-    const fechaActualizar = moment(new Date());
-    // actualiza los agendas en estado pausada, disponible o publicada que se hayan ejecutado el día anterior
+export function actualizarEstadoAgendas(start, end) {
+    // actualiza los agendas en estado pausada, disponible o publicada que se hayan ejecutado entre las fechas start y end
     const condicion = {
         $or: [{ estado: 'disponible' }, { estado: 'publicada' }, { estado: 'pausada' }, { estado: 'pendienteAsistencia' }, { estado: 'pendienteAuditoria' }],
-        // $or: [{ estado: 'disponible' }, { estado: 'publicada' }, { estado: 'pausada' }],
         $and: [
-            { horaInicio: { $gte: (moment(fechaActualizar).startOf('day').subtract(1, 'days').toDate() as any) } },
-            { horaInicio: { $lte: (moment(fechaActualizar).endOf('day').toDate() as any) } }
+            { horaInicio: { $gte: start } },
+            { horaInicio: { $lte: end } }
         ]
     };
     const cursor = agendaModel.find(condicion).cursor();
     return cursor.eachAsync(doc => {
         const agenda: any = doc;
-        let todosAsistencia = true;
-        let todosAuditados = true;
+        let turnos = [];
+        let todosAsistencia = false;
+        let todosAuditados = false;
         for (let j = 0; j < agenda.bloques.length; j++) {
-            const turnos = agenda.bloques[j].turnos;
-            // Verifico si al hay al menos un turno asignado sin asistencia
-            todosAsistencia = !turnos.some(t => t.estado === 'asignado' && !(t.asistencia));
-            todosAuditados = !(turnos.some(t => t.asistencia === 'asistio' && (!t.diagnostico.codificaciones[0] || (t.diagnostico.codificaciones[0] && !t.diagnostico.codificaciones[0].codificacionAuditoria))));
+            turnos = turnos.concat(agenda.bloques[j].turnos);
         }
+        if (agenda.sobreturnos) {
+            turnos = turnos.concat(agenda.sobreturnos);
+        }
+        todosAsistencia = !turnos.some(t => t.estado === 'asignado' && !(t.asistencia));
+        todosAuditados = !(turnos.some(t => t.asistencia === 'asistio' && (!t.diagnostico.codificaciones[0] || (t.diagnostico.codificaciones[0] && !t.diagnostico.codificaciones[0].codificacionAuditoria))));
 
         if (todosAsistencia) {
             if (todosAuditados) {
                 agenda.estado = 'auditada';
+                actualizarAux(agenda);
             } else {
-                agenda.estado = 'pendienteAuditoria';
+                if (agenda.estado !== 'pendienteAuditoria') {
+                    agenda.estado = 'pendienteAuditoria';
+                    actualizarAux(agenda);
+                }
             }
         } else {
-            agenda.estado = 'pendienteAsistencia';
+            if (agenda.estado !== 'pendienteAsistencia') {
+                agenda.estado = 'pendienteAsistencia';
+                actualizarAux(agenda);
+            }
         }
-        Auth.audit(agenda, (userScheduler as any));
-        return saveAgenda(agenda).then((nuevaAgenda) => {
-            Logger.log(userScheduler, 'citas', 'actualizarEstadoAgendas', {
-                idAgenda: agenda._id,
-                organizacion: agenda.organizacion,
-                horaInicio: agenda.horaInicio,
-                updatedAt: agenda.updatedAt,
-                updatedBy: agenda.updatedBy
+    });
+}
 
-            });
-            return Promise.resolve();
-        }).catch(() => {
-            return Promise.resolve();
-        });
+async function actualizarAux(agenda: any) {
+    Auth.audit(agenda, (userScheduler as any));
+    await saveAgenda(agenda);
+    Logger.log(userScheduler, 'citas', 'actualizarEstadoAgendas', {
+        idAgenda: agenda._id,
+        organizacion: agenda.organizacion,
+        horaInicio: agenda.horaInicio,
+        updatedAt: agenda.updatedAt,
+        updatedBy: agenda.updatedBy
     });
 }
 


### PR DESCRIPTION
### Requerimiento
Se requiere corregir estados de las agendas hacia atrás verificando los siguientes casos:

- Agendas sin pacientes asignados -> que pasen a auditadas
- Agendas no nominalizadas -> que pasen a auditadas
- Agendas que hayan quedado con todos los turnos auditados y por algún motivo no hayan pasado a auditadas.

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
