### PR TITLE
rup: agrega semantic tag 'medicamento clínico' a Schema.

### DIFF
--- a/modules/rup/schemas/semantic-tag.ts
+++ b/modules/rup/schemas/semantic-tag.ts
@@ -22,6 +22,7 @@ export let SemanticTag = {
         'situación',
         'trastorno',
         'régimen/tratamiento',
-        'medio ambiente'
+        'medio ambiente',
+        'medicamento clínico'
     ]
 };


### PR DESCRIPTION

### Requerimiento
* Resolver error: 
`profesionalMeta validation failed: frecuentes.346.concepto.semanticTag: `medicamento clínico` is not a valid enum value for path 'concepto.semanticTag'., frecuentes.347.concepto.semanticTag: `medicamento clínico` is not a valid enum value for path 'concepto.semanticTag'.`

### Funcionalidad desarrollada
1. Agrega un semantic tag nuevo al enum del schema.

### UserStories llegó a completarse
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
