### PR TITLE
prestamos: corrige error 'Exceeded memory limit for $group'

### DIFF
--- a/modules/prestamosCarpetas/controller/prestamosController.ts
+++ b/modules/prestamosCarpetas/controller/prestamosController.ts
@@ -220,7 +220,7 @@ async function findCarpetasPrestamo(organizacionId: string, horaInicio: string, 
     pipeline.push({ $sort: sort });
     pipeline.push({ $group: group });
 
-    let result: any = await toArray(Prestamo.aggregate(pipeline).cursor({}).exec());
+    let result: any = await toArray(Prestamo.aggregate(pipeline).allowDiskUse(true).cursor({}).exec());
 
     result = result.filter((el) => {
         return el.estado === constantes.EstadosPrestamosCarpeta.Prestada;
@@ -280,7 +280,7 @@ async function buscarAgendasSobreturnos(organizacionId: string, tipoPrestacion: 
         }
     ];
 
-    return await toArray(agenda.aggregate(pipelineCarpeta).cursor({}).exec());
+    return await toArray(agenda.aggregate(pipelineCarpeta).allowDiskUse(true).cursor({}).exec());
 }
 
 async function buscarAgendasTurnos(organizacionId: string, tipoPrestacion: string, espacioFisico: string, profesional: string, horaInicio: string, horaFin: string) {
@@ -335,7 +335,7 @@ async function buscarAgendasTurnos(organizacionId: string, tipoPrestacion: strin
             }
         }];
 
-    return await toArray(agenda.aggregate(pipelineCarpeta).cursor({}).exec());
+    return await toArray(agenda.aggregate(pipelineCarpeta).allowDiskUse(true).cursor({}).exec());
 }
 
 export async function prestarCarpeta(req) {


### PR DESCRIPTION

### Requerimiento
Corregir: 
`Exceeded memory limit for $group, but didn't allow external sort. Pass allowDiskUse:true to opt in.`

### Funcionalidad desarrollada 
1. Se agrega opción allowDiskUse.


### UserStories llegó a completarse
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No