### PR TITLE
citas: corrige error de envío de datos dos veces.

### DIFF
--- a/modules/turnos/routes/agenda.ts
+++ b/modules/turnos/routes/agenda.ts
@@ -268,11 +268,13 @@ router.post('/agenda', (req, res, next) => {
 
         EventCore.emitAsync('citas:agenda:create', data);
 
+        res.json(data);
 
         // Al crear una nueva agenda la cacheo para Sips
-        operations.cacheTurnos(data).catch(error => { return next(error); });
+        operations.cacheTurnos(data).catch(error => {
+            return error;
+        });
         // Fin de insert cache
-        res.json(data);
     });
 });
 


### PR DESCRIPTION
### Requerimiento
* Cuando fallaba la integración (muy de vez en cuando) se envíaba dos veces una respuesta al cliente, generando un fallo.

`Can't set headers after they are sent.`

### Funcionalidad desarrollada 
1.  Se acomodan las lineas de código para evitar este problema.


### UserStories llegó a completarse
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [ ] Si
- [X] No