### PR TITLE
mpi: Quita update de elastic para campos no importantes

### DIFF
--- a/core/mpi/routes/paciente.ts
+++ b/core/mpi/routes/paciente.ts
@@ -10,7 +10,6 @@ import { ElasticSync } from '../../../utils/elasticSync';
 import * as debug from 'debug';
 import { toArray } from '../../../utils/utils';
 import { EventCore } from '@andes/event-bus';
-import { EventEmitter } from 'events';
 
 
 const logD = debug('paciente-controller');
@@ -187,9 +186,6 @@ router.get('/pacientes/:id', (req, res, next) => {
     }
     controller.buscarPaciente(req.params.id).then((resultado: any) => {
         if (resultado) {
-            Logger.log(req, 'mpi', 'query', {
-                mongoDB: resultado.paciente
-            });
             EventCore.emitAsync('mpi:paciente:get', resultado.paciente);
             res.json(resultado.paciente);
         } else {
@@ -206,10 +202,6 @@ router.get('/pacientes', (req, res, next) => {
     if (!Auth.check(req, 'mpi:paciente:elasticSearch')) {
         return next(403);
     }
-    // Logger de la consulta a ejecutar
-    Logger.log(req, 'mpi', 'query', {
-        elasticSearch: req.query
-    });
 
     controller.matching(req.query).then(result => {
         res.send(result);

--- a/core/mpi/routes/paciente.ts
+++ b/core/mpi/routes/paciente.ts
@@ -708,9 +708,9 @@ router.patch('/pacientes/:id', async (req, res, next) => {
             } else {
                 pacienteAndes = resultado.paciente;
             }
-            let connElastic = new ElasticSync();
-
-            await connElastic.sync(pacienteAndes);
+            // Quitamos esta sincronizacion con elastic para evitar la sincronización de campos no necesarios.
+            // let connElastic = new ElasticSync();
+            // await connElastic.sync(pacienteAndes);
 
             Auth.audit(pacienteAndes, req);
             let pacienteSaved = await pacienteAndes.save();


### PR DESCRIPTION
MPI - Quitamos la sincronización con elastic search para la actualización de campos que no son de búsqueda.

### Requerimiento
* No pertenece a US, es un fix por bug recurrente.

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No
