### PR TITLE
Job turnos mobile

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -318,5 +318,9 @@ export const logKeys = {
     elasticFix2: {
         key: 'elasticFix:update',
         operacion: 'Documentos referidos al paciente modificados'
+    },
+    turnosMobileUpdate: {
+        key: 'citas:bloques:modificar',
+        operacion: 'setea a 0 turnos disponibles para app mobile'
     }
 };

--- a/core/log/schemas/log.ts
+++ b/core/log/schemas/log.ts
@@ -40,7 +40,7 @@ export let logSchema = new mongoose.Schema({
             // OperacionesElastic
             'elasticInsert', 'elasticInsertInPut', 'elasticUpdate', 'elasticDelete', 'elasticError',
             // ... Citas
-            'asignarTurno', 'cancelarTurno', 'listaEspera', 'actualizarTiposDeTurno', 'actualizarEstadoAgendas', 'actualizarTurnosDelDia', 'lista espera', 'actualizarTurnosMobile',
+            'asignarTurno', 'cancelarTurno', 'listaEspera', 'actualizarTiposDeTurno', 'actualizarEstadoAgendas', 'actualizarTurnosDelDia', 'lista espera',
             // ... RUP
             // hudsPantalla -> Profesional entra a la pantalla de huds de un paciente
             // hudsPrestacion -> Profesional abre una pretación para ver en la pantalla de ver huds

--- a/core/log/schemas/log.ts
+++ b/core/log/schemas/log.ts
@@ -40,7 +40,7 @@ export let logSchema = new mongoose.Schema({
             // OperacionesElastic
             'elasticInsert', 'elasticInsertInPut', 'elasticUpdate', 'elasticDelete', 'elasticError',
             // ... Citas
-            'asignarTurno', 'cancelarTurno', 'listaEspera', 'actualizarTiposDeTurno', 'actualizarEstadoAgendas', 'actualizarTurnosDelDia', 'lista espera',
+            'asignarTurno', 'cancelarTurno', 'listaEspera', 'actualizarTiposDeTurno', 'actualizarEstadoAgendas', 'actualizarTurnosDelDia', 'lista espera', 'actualizarTurnosMobile',
             // ... RUP
             // hudsPantalla -> Profesional entra a la pantalla de huds de un paciente
             // hudsPrestacion -> Profesional abre una pretación para ver en la pantalla de ver huds

--- a/jobs/actualizarTurnosMobile.ts
+++ b/jobs/actualizarTurnosMobile.ts
@@ -1,0 +1,11 @@
+import * as agendaCtrl from './../modules/turnos/controller/agenda';
+
+function run(done) {
+    agendaCtrl.actualizarTurnosMobile().then(() => {
+        done();
+    }).catch(() => {
+        done();
+    });
+}
+
+export = run;

--- a/modules/turnos/controller/agenda.ts
+++ b/modules/turnos/controller/agenda.ts
@@ -13,6 +13,9 @@ import {
 import {
     Logger
 } from '../../../utils/logService';
+import { log } from '@andes/log';
+import { logKeys } from '../../../config';
+
 import {
     model as Prestacion
 } from '../../rup/schemas/prestacion';
@@ -904,15 +907,24 @@ export async function actualizarTurnosMobile() {
             }
         }
         Auth.audit(agenda, (userScheduler as any));
-        return saveAgenda(agenda).then(() => {
-            Logger.log(userScheduler, 'citas', 'actualizarTurnosMobile', {
-                idAgenda: agenda._id,
-                organizacion: agenda.organizacion,
-                horaInicio: agenda.horaInicio,
-                updatedAt: agenda.updatedAt,
-                updatedBy: agenda.updatedBy
+        return saveAgenda(agenda).then(async () => {
 
-            });
+            let logRequest = {
+                user: {
+                    usuario: { nombre: 'actualizarTurnosMobileJob', apellido: 'actualizarTurnosMobileJob' },
+                    app: 'citas',
+                    organizacion: userScheduler.user.organizacion.nombre
+                },
+                ip: 'localhost',
+                connection: {
+                    localAddress: ''
+                }
+            };
+            try {
+                await log(logRequest, logKeys.turnosMobileUpdate.key, null, logKeys.turnosMobileUpdate.operacion, null, null);
+            } catch (err) {
+                await log(logRequest, logKeys.turnosMobileUpdate.key, null, logKeys.turnosMobileUpdate.operacion, err, null);
+            }
             return Promise.resolve();
         }).catch(() => {
             return Promise.resolve();

--- a/modules/turnos/controller/agenda.ts
+++ b/modules/turnos/controller/agenda.ts
@@ -891,7 +891,7 @@ export function actualizarTurnosMobile() {
     const fechaActualizar = moment().add(1, 'day');
 
     const condicion = {
-        $or: [{ estado: 'disponible' }, { estado: 'publicada' }],
+        $or: [{ estado: 'disponible' }, { estado: 'publicada' }, { estado: 'pausada' }],
         horaInicio: {
             $gte: (moment(fechaActualizar).startOf('day').toDate() as any),
             $lte: (moment(fechaActualizar).endOf('day').toDate() as any)

--- a/modules/turnos/controller/agenda.ts
+++ b/modules/turnos/controller/agenda.ts
@@ -887,7 +887,7 @@ export function actualizarTurnosDelDia() {
  * @export actualizarTurnosMobile()
  * @returns resultado
  */
-export async function actualizarTurnosMobile() {
+export function actualizarTurnosMobile() {
     const fechaActualizar = moment().add(1, 'day');
 
     const condicion = {
@@ -910,9 +910,9 @@ export async function actualizarTurnosMobile() {
             localAddress: ''
         }
     };
-    try {
-        return await cursor.eachAsync(async doc => {
-            const agenda: any = doc;
+    return cursor.eachAsync(async doc => {
+        const agenda: any = doc;
+        try {
             for (let j = 0; j < agenda.bloques.length; j++) {
                 if (agenda.bloques[j].restantesMobile > 0) {
                     agenda.bloques[j].restantesMobile = 0;
@@ -920,12 +920,10 @@ export async function actualizarTurnosMobile() {
             }
             Auth.audit(agenda, (userScheduler as any));
             await saveAgenda(agenda);
-            await log(logRequest, logKeys.turnosMobileUpdate.key, null, logKeys.turnosMobileUpdate.operacion, null, { idAgenda: agenda._id });
-        });
-    } catch (err) {
-        await log(logRequest, logKeys.turnosMobileUpdate.key, null, logKeys.turnosMobileUpdate.operacion, err, null);
-        return Promise.reject(err);
-    }
+        } catch (err) {
+            await log(logRequest, logKeys.turnosMobileUpdate.key, null, logKeys.turnosMobileUpdate.operacion, err, { idAgenda: agenda._id });
+        }
+    });
 }
 
 /**

--- a/modules/turnos/controller/agenda.ts
+++ b/modules/turnos/controller/agenda.ts
@@ -884,7 +884,7 @@ export function actualizarTurnosDelDia() {
  * @export actualizarTurnosMobile()
  * @returns resultado
  */
-export function actualizarTurnosMobile() {
+export async function actualizarTurnosMobile() {
     const fechaActualizar = moment().add(1, 'day');
 
     const condicion = {
@@ -892,7 +892,8 @@ export function actualizarTurnosMobile() {
         horaInicio: {
             $gte: (moment(fechaActualizar).startOf('day').toDate() as any),
             $lte: (moment(fechaActualizar).endOf('day').toDate() as any)
-        }
+        },
+        'bloques.restantesMobile': { $gt: 0 }
     };
     const cursor = agendaModel.find(condicion).cursor();
     return cursor.eachAsync(doc => {
@@ -902,7 +903,6 @@ export function actualizarTurnosMobile() {
                 agenda.bloques[j].restantesMobile = 0;
             }
         }
-
         Auth.audit(agenda, (userScheduler as any));
         return saveAgenda(agenda).then(() => {
             Logger.log(userScheduler, 'citas', 'actualizarTurnosMobile', {
@@ -917,7 +917,6 @@ export function actualizarTurnosMobile() {
         }).catch(() => {
             return Promise.resolve();
         });
-
     });
 }
 


### PR DESCRIPTION
### Requerimiento
* Implementar job que setee a 0 los turnos disponibles para la aplicación mobile el día anterior a la ejecución de la agenda a las 12 hs

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

Requiere agregar en el array de jobs del config.private lo siguiente
{
        when: '0 12 * * *',
        action: './jobs/actualizarTurnosMobile'
}


