### PR TITLE
TurnosMobile - Fix bug consulta georeferencia

### DIFF
--- a/modules/mobileApp/routes/agendas.ts
+++ b/modules/mobileApp/routes/agendas.ts
@@ -39,27 +39,22 @@ router.get('/agendasDisponibles', async (req: any, res, next) => {
         $sort: { 'agendas.horaInicio': 1 }
     });
     let agendasResultado = await toArray(agenda.aggregate(pipelineAgendas).cursor({}).exec());
-    const promisesStack = [];
     try {
         for (let i = 0; i <= agendasResultado.length - 1; i++) {
             const org: any = await Organizacion.findById(agendasResultado[i].id);
-            if (org.codigo && org.codigo.sisa && org.turnosMobile) {
+            if (org.codigo && org.codigo.sisa && org.turnosMobile && org.direccion && org.direccion.geoReferencia) {
                 agendasResultado[i].coordenadasDeMapa = {
                     latitud: org.direccion.geoReferencia[0],
                     longitud: org.direccion.geoReferencia[1]
                 };
-                agendasResultado[i].coordenadasDeMapa.longitud = org.direccion.geoReferencia[1];
                 agendasResultado[i].domicilio = org.direccion.valor;
-                promisesStack.push(org);
             }
         }
-        await Promise.all(promisesStack);
         res.json(agendasResultado);
     } catch (err) {
         res.status(422).json({ message: err });
     }
-
 });
 
-
 export = router;
+


### PR DESCRIPTION
### Requerimiento
* Corrige bug que ocurría cuando el efector no estaba georeferenciado y tenía agendas con cupo para turnos mobile.

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No