### PR TITLE
RUP/CITAS: Soluciona la duplicación de auditoría: Fix1110

### DIFF
--- a/modules/rup/controllers/codificacionController.ts
+++ b/modules/rup/controllers/codificacionController.ts
@@ -3,8 +3,8 @@ import * as cie10 from './../../../core/term/schemas/cie10';
 import { EventCore } from '@andes/event-bus';
 import * as codificacion from '../schemas/codificacion';
 
-EventCore.on('rup:prestacion:romperValidacion', async (idPrestacion) => {
-    await codificacion.findOneAndRemove({ idPrestacion });
+EventCore.on('rup:prestacion:romperValidacion', async (prestacion) => {
+    await codificacion.findOneAndRemove({ idPrestacion: prestacion.id });
 });
 
 export function codificarPrestacion(unaPrestacion: any) {

--- a/modules/rup/controllers/codificacionController.ts
+++ b/modules/rup/controllers/codificacionController.ts
@@ -1,5 +1,11 @@
 import { SnomedCIE10Mapping } from '../../../core/term/controller/mapping';
 import * as cie10 from './../../../core/term/schemas/cie10';
+import { EventCore } from '@andes/event-bus';
+import * as codificacion from '../schemas/codificacion';
+
+EventCore.on('rup:prestacion:romperValidacion', async (idPrestacion) => {
+    await codificacion.findOneAndRemove({ idPrestacion });
+});
 
 export function codificarPrestacion(unaPrestacion: any) {
     return new Promise((resolve, reject) => {

--- a/modules/rup/controllers/codificacionController.ts
+++ b/modules/rup/controllers/codificacionController.ts
@@ -22,7 +22,6 @@ export function codificarPrestacion(unaPrestacion: any) {
                 };
                 const map = new SnomedCIE10Mapping(parametros.paciente, parametros.secondaryConcepts);
                 map.transform(parametros.conceptId).then(target => {
-
                     if (target) {
                         // Buscar en cie10 los primeros 5 digitos
                         cie10.model.findOne({

--- a/modules/rup/routes/codificacion.ts
+++ b/modules/rup/routes/codificacion.ts
@@ -13,7 +13,6 @@ const router = express.Router();
 router.post('/codificacion', async (req, res, next) => {
     const idPrestacion = req.body.idPrestacion;
     const unaPrestacion = await prestacion.model.findById(idPrestacion);
-    await codificacion.findOneAndRemove({ idPrestacion });
     const codificaciones = await codificacionController.codificarPrestacion(unaPrestacion);
     let data = new codificacion({
         idPrestacion,

--- a/modules/rup/routes/codificacion.ts
+++ b/modules/rup/routes/codificacion.ts
@@ -13,6 +13,7 @@ const router = express.Router();
 router.post('/codificacion', async (req, res, next) => {
     const idPrestacion = req.body.idPrestacion;
     const unaPrestacion = await prestacion.model.findById(idPrestacion);
+    await codificacion.findOneAndRemove({ idPrestacion });
     const codificaciones = await codificacionController.codificarPrestacion(unaPrestacion);
     let data = new codificacion({
         idPrestacion,

--- a/modules/rup/routes/prestacion.ts
+++ b/modules/rup/routes/prestacion.ts
@@ -591,7 +591,8 @@ router.patch('/prestaciones/:id', (req, res, next) => {
             }
 
             if (req.body.op === 'romperValidacion') {
-                EventCore.emitAsync('rup:prestacion:romperValidacion', data.id);
+                const _prestacion = data;
+                EventCore.emitAsync('rup:prestacion:romperValidacion', _prestacion);
             }
 
             if (req.body.planes) {

--- a/modules/rup/routes/prestacion.ts
+++ b/modules/rup/routes/prestacion.ts
@@ -12,7 +12,6 @@ import { snomedModel } from '../../../core/term/schemas/snomed';
 import * as camasController from './../controllers/cama';
 import { parseDate } from './../../../shared/parse';
 import { EventCore } from '@andes/event-bus';
-import { facturacionAutomatica } from './../../facturacionAutomatica/controllers/facturacionAutomatica';
 
 const router = express.Router();
 import async = require('async');
@@ -527,8 +526,6 @@ router.patch('/prestaciones/:id', (req, res, next) => {
                         return next('Solo puede romper la validación el usuario que haya creado.');
                     }
                 }
-
-
                 data.estados.push(req.body.estado);
                 break;
             case 'registros':
@@ -555,7 +552,7 @@ router.patch('/prestaciones/:id', (req, res, next) => {
                 return next(500);
         }
         Auth.audit(data, req);
-        data.save((error, prestacion) => {
+        data.save(async (error, prestacion) => {
             if (error) {
                 return next(error);
             }
@@ -591,6 +588,10 @@ router.patch('/prestaciones/:id', (req, res, next) => {
                     return next(errFrec);
                 });
 
+            }
+
+            if (req.body.op === 'romperValidacion') {
+                EventCore.emitAsync('rup:prestacion:romperValidacion', data.id);
             }
 
             if (req.body.planes) {


### PR DESCRIPTION
Soluciona el problema de la duplicación en la auditoría cuando se rompe la validación y se vuelve a validar la prestación.

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No