### PR TITLE
CITAS: Auditoría "automática" de agendas de enfermeria y odonto

### DIFF
--- a/core/tm/schemas/tipoPrestacion.ts
+++ b/core/tm/schemas/tipoPrestacion.ts
@@ -5,8 +5,7 @@ export interface ITipoPrestacion extends Document {
     conceptId: String;
     term: String;
     fsn: String;
-    semanticTag: 'procedimiento' | 'solicitud' | 'hallazgo' | 'trastorno' | 'antecedenteFamiliar'| 'régimen/tratamiento';
-
+    semanticTag: 'procedimiento' | 'solicitud' | 'hallazgo' | 'trastorno' | 'antecedenteFamiliar' | 'régimen/tratamiento';
 }
 
 
@@ -18,7 +17,12 @@ export let tipoPrestacionSchema = new Schema({
         type: String,
         enum: ['procedimiento', 'solicitud', 'hallazgo', 'trastorno', 'antecedenteFamiliar', 'régimen/tratamiento']
     },
-    noNominalizada: Boolean
+    noNominalizada: Boolean,
+    auditable: {
+        type: Boolean,
+        required: false,
+        default: true
+    }
 });
 
 /* Se definen los campos virtuals */

--- a/modules/turnos/schemas/turno.ts
+++ b/modules/turnos/schemas/turno.ts
@@ -4,7 +4,6 @@ import * as cie10 from '../../../core/term/schemas/cie10';
 import * as nombreSchema from '../../../core/tm/schemas/nombre';
 import * as obraSocialSchema from '../../obraSocial/schemas/obraSocial';
 import { SnomedConcept } from '../../rup/schemas/snomed-concept';
-import * as IEstadoFacturacion from '../../facturacionAutomatica/schemas/estadoFacturacion';
 
 const pacienteSchema = new mongoose.Schema({
     id: mongoose.Schema.Types.ObjectId,
@@ -77,6 +76,7 @@ const turnoSchema = new mongoose.Schema({
         type: mongoose.Schema.Types.ObjectId,
         ref: 'prestacionPaciente'
     },
+    auditable: Boolean,
     // Unificamos los diagnósticos(codificaciones) en un solo arreglo, el DIAGNOSTICO PRINCIPAL será el que este en la posición 0.
     // Si ambas codificaciones coinciden, la auditoría aprobó la cod.
     // Si las codificaciones difieren, auditoría realizo un reparo


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
U.S. https://pm.andes.gob.ar/projects/andes/work_packages/803/activity?query_props=%7B%22c%22:%5B%22id%22,%22subject%22,%22type%22,%22status%22,%22assignee%22,%22updatedAt%22%5D,%22tzl%22:%22days%22,%22hi%22:true,%22g%22:%22%22,%22t%22:%22id:desc,parent:asc%22,%22f%22:%5B%7B%22n%22:%22status%22,%22o%22:%22o%22,%22v%22:%5B%5D%7D%5D,%22pa%22:1,%22pp%22:20%7D

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
Se agrega el atributo "auditable: false" en DB a los conceptos turneables de "consulta de enfermeria/odontología". El mismo atributo queda agregado en el esquema de tipoPrestaciones (por defecto en true) y de turno (se asigna el valor correspondiente al tipoPrestacion). 
Al momento de actualizar el estado de las agendas (job) si alguna contiene al menos un bloque con una de estas dos prestaciones, automáticamente pasara al estado "auditada".

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [X] Si
- [ ] No

Coleccion "conceptoTurneable": Agregar el atributo "auditable: false" a los documentos con conceptId: 34043003 y 861000013109
<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
