### PR TITLE
fix(citas): loggin reasignar sobreturnos

### DIFF
--- a/modules/turnos/routes/turno.ts
+++ b/modules/turnos/routes/turno.ts
@@ -461,7 +461,8 @@ router.put('/turno/:idTurno/bloque/:idBloque/agenda/:idAgenda/', async (req, res
                 res.json(doc2);
                 if (req.body.turno.reasignado && req.body.turno.reasignado.siguiente) {
                     const turno = doc2.bloques.id(req.params.idBloque).turnos.id(req.params.idTurno);
-                    LoggerPaciente.logTurno(req, 'turnos:reasignar', req.body.turno.paciente, turno, req.params.idBloque, req.params.idAgenda);
+                    const idBloque = req.params.idBloque !== '-1' ? null : Types.ObjectId(req.params.idBloque);
+                    LoggerPaciente.logTurno(req, 'turnos:reasignar', req.body.turno.paciente, turno, idBloque, req.params.idAgenda);
                     NotificationService.notificarReasignar(req.params);
                 }
 


### PR DESCRIPTION
### Requerimiento
Corrigir este bug:

```
CastError: Cast to ObjectID failed for value "-1" at path "dataTurno.idBloque"
    at new CastError (/var/www/andes/api/source/node_modules/mongoose/lib/error/cast.js:29:11)
    at model.$set (/var/www/andes/api/source/node_modules/mongoose/lib/document.js:1030:7)
    at model._handleIndex (/var/www/andes/api/source/node_modules/mongoose/lib/document.js:806:14)
    at model.$set (/var/www/andes/api/source/node_modules/mongoose/lib/document.js:756:22)
    at model._handleIndex (/var/www/andes/api/source/node_modules/mongoose/lib/document.js:786:12)
    at model.$set (/var/www/andes/api/source/node_modules/mongoose/lib/document.js:756:22)
```

### UserStories llegó a completarse
- [ ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [ ] Si
- [ ] No
