### PR TITLE
TOP: Quita solicitudes generadas desde RUP

### DIFF
--- a/modules/rup/routes/prestacion.ts
+++ b/modules/rup/routes/prestacion.ts
@@ -324,6 +324,9 @@ router.get('/prestaciones/solicitudes', (req, res, next) => {
         query.where('solicitud.tipoPrestacion.id').equals(req.query.prestacionDestino);
     }
 
+    query.where('solicitud.registros.0.esSolicitud').equals(false);
+
+
     if (req.query.organizacionOrigen) {
         const arr: any[] = [];
         arr.push({ 'solicitud.organizacionOrigen': { $exists: true } });


### PR DESCRIPTION
### Requerimiento
En el módulo TOP dejar de visualizar las solicitudes generadas desde RUP

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
