### PR TITLE
RUP: fix de informes en adjuntos sin descripción

### DIFF
--- a/modules/descargas/controller/descargas.ts
+++ b/modules/descargas/controller/descargas.ts
@@ -257,15 +257,16 @@ export class Documento {
 
                         archivo.stream.on('end', () => {
                             adjunto = `<img class="w-25" src="data:image/${documento.ext};base64,${Buffer.concat(file).toString('base64')}">`;
-                            templateAdjuntos = template.replace('<!--descripcion-->', documento.descripcion.term).replace('<!--adjunto-->', adjunto);
+                            const descripcion = documento.descripcion && documento.descripcion.term ? documento.descripcion.term : '';
+                            templateAdjuntos = template.replace('<!--descripcion-->', descripcion).replace('<!--adjunto-->', adjunto);
                             resolve(templateAdjuntos);
                         });
-
                     });
                 });
             } else {
                 const tipoArchivo = this.tipoDeArchivo(documento.ext);
-                return templateNoSoportado.replace('<!--descripcion-->', documento.descripcion.term).replace('<!--formato-->', `${tipoArchivo} (${documento.ext.toUpperCase()}, no se visualiza)`);
+                const descripcion = documento.descripcion && documento.descripcion.term ? documento.descripcion.term : '';
+                return templateNoSoportado.replace('<!--descripcion-->', descripcion).replace('<!--formato-->', `${tipoArchivo} (${documento.ext.toUpperCase()}, no se visualiza)`);
             }
 
         });

--- a/templates/rup/informes/html/includes/adjunto.html
+++ b/templates/rup/informes/html/includes/adjunto.html
@@ -1,4 +1,5 @@
-<div class="contenedor-concepto-data adjunto" style="page-break-before: always; page-break-after: always;">
+<div class="contenedor-concepto-data adjunto mb-4 border-bottom"
+    style="page-break-before: always; page-break-after: always;">
     <h3 class="text-uppercase">
         Adjunto:
         <!--descripcion-->
@@ -6,4 +7,3 @@
     <hr class="sm" />
     <!--adjunto-->
 </div>
-<br>

--- a/templates/rup/informes/sass/main.scss
+++ b/templates/rup/informes/sass/main.scss
@@ -257,6 +257,9 @@ main {
     }
 
     .adjunto {
+        padding: .5cm 0;
+        border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+
         small {
             font-size: 0.25cm;
         }


### PR DESCRIPTION
### Requerimiento
Si no existe descripción de un archivo adjunto, la descarga falla

### Funcionalidad desarrollada 
1. Se agregó un control para verificar que la descripción exista, caso contrario no se muestra nada (string vacío)


### UserStories llegó a completarse
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [X] No

