### PR TITLE
Audita automáticamente agendas de prestaciones no auditables

### DIFF
--- a/core/tm/schemas/tipoPrestacion.ts
+++ b/core/tm/schemas/tipoPrestacion.ts
@@ -5,7 +5,7 @@ export interface ITipoPrestacion extends Document {
     conceptId: String;
     term: String;
     fsn: String;
-    semanticTag: 'procedimiento' | 'solicitud' | 'hallazgo' | 'trastorno' | 'antecedenteFamiliar'| 'régimen/tratamiento';
+    semanticTag: 'procedimiento' | 'solicitud' | 'hallazgo' | 'trastorno' | 'antecedenteFamiliar' | 'régimen/tratamiento';
 
 }
 
@@ -18,7 +18,12 @@ export let tipoPrestacionSchema = new Schema({
         type: String,
         enum: ['procedimiento', 'solicitud', 'hallazgo', 'trastorno', 'antecedenteFamiliar', 'régimen/tratamiento']
     },
-    noNominalizada: Boolean
+    noNominalizada: Boolean,
+    auditable: {
+        type: Boolean,
+        required: false,
+        default: true
+    }
 });
 
 /* Se definen los campos virtuals */

--- a/modules/turnos/controller/agenda.ts
+++ b/modules/turnos/controller/agenda.ts
@@ -797,7 +797,7 @@ export function actualizarEstadoAgendas(start, end) {
             turnos = turnos.concat(agenda.sobreturnos);
         }
         todosAsistencia = !turnos.some(t => t.estado === 'asignado' && !(t.asistencia));
-        todosAuditados = !(turnos.some(t => t.asistencia === 'asistio' && (!t.diagnostico.codificaciones[0] || (t.diagnostico.codificaciones[0] && !t.diagnostico.codificaciones[0].codificacionAuditoria))));
+        todosAuditados = !(turnos.some(t => t.asistencia === 'asistio' && t.auditable === true && (!t.diagnostico.codificaciones[0] || (t.diagnostico.codificaciones[0] && !t.diagnostico.codificaciones[0].codificacionAuditoria))));
 
         if (todosAsistencia) {
             if (todosAuditados) {

--- a/modules/turnos/schemas/turno.ts
+++ b/modules/turnos/schemas/turno.ts
@@ -77,6 +77,7 @@ const turnoSchema = new mongoose.Schema({
         type: mongoose.Schema.Types.ObjectId,
         ref: 'prestacionPaciente'
     },
+    auditable: Boolean,
     // Unificamos los diagnósticos(codificaciones) en un solo arreglo, el DIAGNOSTICO PRINCIPAL será el que este en la posición 0.
     // Si ambas codificaciones coinciden, la auditoría aprobó la cod.
     // Si las codificaciones difieren, auditoría realizo un reparo


### PR DESCRIPTION
### Requerimiento
U.S. https://pm.andes.gob.ar/projects/citas/work_packages/803/activity
### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
Se agrega el atributo "auditable: false" en DB a los conceptos turneables de "consulta de enfermeria/odontología". El mismo atributo queda agregado en el esquema de tipoPrestaciones (por defecto en true) y de turno (se asigna el valor correspondiente al tipoPrestacion). 
Al momento de actualizar el estado de las agendas (job) si alguna contiene al menos un bloque con una de estas dos prestaciones, automáticamente pasara al estado "auditada" cuando corre el job que actualiza agendas.

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [X] Si
- [ ] No

Coleccion "conceptoTurneable": Agregar el atributo "auditable: false" a los documentos con conceptId: 34043003 y 861000013109
<!-- Agregar captura de pantalla, si fuera relevante  -->

