### PR TITLE
pecas: separa constantes de conexión

### DIFF
--- a/config.private.ts.example
+++ b/config.private.ts.example
@@ -260,7 +260,8 @@ export const consolidadoPecas = {
 };
 
 export const fueraAgendaPecas = {
-      auth: {
+
+    auth: {
         user: '',
         password: ''
     },

--- a/config.private.ts.example
+++ b/config.private.ts.example
@@ -244,7 +244,8 @@ export const wsSalud = {
     hpnWS: '',
 };
 
-export const conSqlPecas = {
+
+export const consolidadoPecas = {
     auth: {
         user: '',
         password: ''
@@ -255,7 +256,20 @@ export const conSqlPecas = {
     },
     table: {
         pecasTable: 'pecas_consolidadoPrueba',
-        fueraAgenda: ''
+    }
+};
+
+export const fueraAgendaPecas = {
+      auth: {
+        user: '',
+        password: ''
+    },
+    serverSql: {
+        server: '',
+        database: ''
+    },
+    table: {
+        fueraAgenda: 'pecas_consolidadoPrueba',
     }
 };
 

--- a/modules/estadistica/pecas/controller/agenda.ts
+++ b/modules/estadistica/pecas/controller/agenda.ts
@@ -10,10 +10,10 @@ import { emailListString } from '../../../../config.private';
 
 let poolTurnos;
 const config = {
-    user: configPrivate.conSqlPecas.auth.user,
-    password: configPrivate.conSqlPecas.auth.password,
-    server: configPrivate.conSqlPecas.serverSql.server,
-    database: configPrivate.conSqlPecas.serverSql.database,
+    user: configPrivate.consolidadoPecas.auth.user,
+    password: configPrivate.consolidadoPecas.auth.password,
+    server: configPrivate.consolidadoPecas.serverSql.server,
+    database: configPrivate.consolidadoPecas.serverSql.database,
     connectionTimeout: 10000,
     requestTimeout: 45000
 };
@@ -103,7 +103,7 @@ async function insertCompleto(turno: any, idEfectorSips) {
     let numeroBloque = turno.sobreturno === 'SI' ? -1 : turno.numeroBloque;
 
 
-    let queryInsert = 'INSERT INTO ' + configPrivate.conSqlPecas.table.pecasTable +
+    let queryInsert = 'INSERT INTO ' + configPrivate.consolidadoPecas.table.pecasTable +
         '(idEfector, Efector, TipoEfector, DescTipoEfector, IdZona, Zona, SubZona, idEfectorSuperior, EfectorSuperior, AreaPrograma, ' +
         'idAgenda, FechaAgenda, HoraAgenda, estadoAgenda, numeroBloque, turnosProgramados, turnosProfesional, turnosLlaves, turnosDelDia, ' +
         'idTurno, estadoTurno, tipoTurno, sobreturno, FechaConsulta, HoraTurno, Periodo, Tipodeconsulta, estadoTurnoAuditoria, Principal, ConsC2, ConsObst, tipoPrestacion, ' +
@@ -151,7 +151,7 @@ async function insertCompleto(turno: any, idEfectorSips) {
 }
 
 async function eliminaAgenda(idAgenda) {
-    let query = `DELETE FROM ${configPrivate.conSqlPecas.table.pecasTable} WHERE idAgenda ='${idAgenda}'`;
+    let query = `DELETE FROM ${configPrivate.consolidadoPecas.table.pecasTable} WHERE idAgenda ='${idAgenda}'`;
     try {
         return executeQuery(query);
     } catch (err) {

--- a/modules/estadistica/pecas/controller/fueraDeAgenda.ts
+++ b/modules/estadistica/pecas/controller/fueraDeAgenda.ts
@@ -11,10 +11,10 @@ import { emailListString } from '../../../../config.private';
 
 let poolPrestaciones;
 const config = {
-    user: configPrivate.conSqlPecas.auth.user,
-    password: configPrivate.conSqlPecas.auth.password,
-    server: configPrivate.conSqlPecas.serverSql.server,
-    database: configPrivate.conSqlPecas.serverSql.database,
+    user: configPrivate.fueraAgendaPecas.auth.user,
+    password: configPrivate.fueraAgendaPecas.auth.password,
+    server: configPrivate.fueraAgendaPecas.serverSql.server,
+    database: configPrivate.fueraAgendaPecas.serverSql.database,
     connectionTimeout: 10000,
     requestTimeout: 45000
 };
@@ -316,7 +316,7 @@ async function auxiliar(pres: any) {
         prestacion.telefono = pres.paciente && pres.paciente.telefono ? pres.paciente.telefono : '';
         let fechaNac = (prestacion.FechaNacimiento && moment(prestacion.FechaNacimiento).year()) > 1900 ? `'${prestacion.FechaNacimiento}'` : null;
 
-        let queryInsert = 'INSERT INTO ' + configPrivate.conSqlPecas.table.fueraAgenda +
+        let queryInsert = 'INSERT INTO ' + configPrivate.fueraAgendaPecas.table.fueraAgenda +
             '(idEfector, Efector, TipoEfector, DescTipoEfector, IdZona, Zona, SubZona, idEfectorSuperior, EfectorSuperior, AreaPrograma, ' +
             'FechaConsulta, Periodo, Tipodeconsulta, estadoAuditoria, Principal, ConsC2, ConsObst, tipoPrestacion, DNI, Apellido, Nombres, ' +
             'HC, CodSexo, Sexo, FechaNacimiento, Edad, UniEdad, CodRangoEdad, RangoEdad, IdObraSocial, ObraSocial, IdPaciente, telefono, ' +
@@ -366,7 +366,7 @@ function organizacionesExcluidas() {
 
 async function eliminaPrestacion(idPrestacion: string) {
     const result = new sql.Request(poolPrestaciones);
-    let query = `DELETE FROM ${configPrivate.conSqlPecas.table.fueraAgenda} WHERE idPrestacion='${idPrestacion}'`;
+    let query = `DELETE FROM ${configPrivate.fueraAgendaPecas.table.fueraAgenda} WHERE idPrestacion='${idPrestacion}'`;
     return executeQuery(query);
 }
 


### PR DESCRIPTION
### Requerimiento
Separa las constantes de conexión a sql para que el consolidado se conecte a un server y fuera de agenda a otro.

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No
