### PR TITLE
fix(webhook): Error de tipeo en el esquema

### DIFF
--- a/modules/webhook/schemas/webhookSchema.ts
+++ b/modules/webhook/schemas/webhookSchema.ts
@@ -12,7 +12,7 @@ export const WebHookSchema = new mongoose.Schema({
     headers: mongoose.SchemaTypes.Mixed, // for Token AUTH
     data: mongoose.SchemaTypes.Mixed, // a projections of data to send
     filters: [mongoose.SchemaTypes.Mixed], // posibles filtros filtros
-    transform: {
+    trasform: {
         type: String,
         required: false
     },


### PR DESCRIPTION
Se resuelve error de tipeo en el esquema de webhook. Lo que no permitía devolver los datos y filtrar por los que tenían activado fhir como método de transformación.