### PR TITLE
fix(gestor-usuarios): ajuste get perfiles permisos

### DIFF
--- a/modules/gestor-usuarios/perfil.routes.ts
+++ b/modules/gestor-usuarios/perfil.routes.ts
@@ -10,8 +10,8 @@ class PerfilesResource extends ResourceBase {
     resourceName = 'perfiles';
     middlewares = [Auth.authenticate()];
     routesAuthorization = {
-        get: Auth.authorize('usuarios:perfiles:?'),
-        search: Auth.authorize('usuarios:perfiles:?'),
+        get: Auth.authorize('usuarios:perfiles:read'),
+        search: Auth.authorize('usuarios:perfiles:read'),
         post: Auth.authorize('usuarios:perfiles:write'),
         patch: Auth.authorize('usuarios:perfiles:write'),
         delete: Auth.authorize('usuarios:perfiles:write'),


### PR DESCRIPTION
### Requerimiento
https://github.com/andes/app/issues/1465

### Funcionalidad desarrollada 
Se cambia el string del permiso a `usuarios:perfiles:read` porque el Auth.authorize no toma los caracteres especiales de shiro porque usa internamente la función `check` y no `permissions`. 

### UserStories llegó a completarse
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [ ] No

 