### PR TITLE
feat(snomed): implementa api snowstorm

### DIFF
--- a/config.private.ts.example
+++ b/config.private.ts.example
@@ -120,10 +120,14 @@ export const puco = {
     }
 };
 
-
 export const snomed = {
+    adapter: getEnv('SNOMED_ADAPTER', 'snowstorm'),
     dbName: getEnv('SNOMED_DB', 'es-edition'),
-    dbVersion: getEnv('SNOMED_VERSION', 'v20171200')
+    dbVersion: getEnv('SNOMED_VERSION', 'v20171200'),
+
+    snowstormHost: getEnv('SNOWSTORM_HOST', 'http://localhost:8080'),
+    snowstormElastic: getEnv('SNOWSTORM_ELASTIC', 'http://localhost:9201'),
+    snowstormBranch: getEnv('SNOWSTORM_BRANCH', 'MAIN/SNOMEDCT-ES')
 };
 
 // Push Notifications

--- a/core/term/controller/snomed.controller.ts
+++ b/core/term/controller/snomed.controller.ts
@@ -1,0 +1,51 @@
+import * as SnomedMongo from './snomed.mongo';
+import * as SnomedSnowstorm from './snomed.snowstorm';
+
+import { snomed } from '../../../config.private';
+
+export interface ISnomedController {
+    /**
+     * Devuelve un concepto snomed completo
+     */
+    getConcept(sctid: String, format?);
+
+    filterRelationships(concept: any, options: { parent: Boolean });
+
+    /**
+     * Busca los hijos o descendientes de un concepto.
+     */
+
+    getChildren(sctid: String, options: { all?: Boolean, completed?: Boolean, leaf?: Boolean });
+
+    /**
+     * Procesa una expression ECL de Snomed y busca en la base de datos.
+     */
+
+    getConceptByExpression(expression: String, termSearch?: String | null, form?: String, languageCode?: String);
+
+    /**
+     * Busca un array de conceptos SNOMED.
+     */
+
+    getConcepts(conceptsIds: String[]);
+
+    /**
+     * Busca conceptos por un texto.
+     * Para el buscador de RUP.
+     */
+
+    searchTerms(text: String, options: { semanticTags?: String[], languageCode?: 'es' | 'en' });
+}
+
+export let SnomedCtr: ISnomedController = null;
+
+const adapter = {
+    snowstorm: SnomedSnowstorm,
+    mongo: SnomedMongo
+};
+
+SnomedCtr = adapter[snomed.adapter.toLowerCase()];
+
+if (!SnomedCtr) {
+    throw new Error('SNOMED_ADAPTER must be mongo or snowstorm');
+}

--- a/core/term/controller/snomed.mongo.ts
+++ b/core/term/controller/snomed.mongo.ts
@@ -1,5 +1,6 @@
-import { SnomedModel } from '../schemas/snomed';
+import { SnomedModel, TextIndexModel } from '../schemas/snomed';
 import { makeMongoQuery } from './grammar/parser';
+import * as utils from '../../../utils/utils';
 
 // ID del atributo que genera una relación padre-hijo
 const IsASct = '116680003';
@@ -39,7 +40,7 @@ export function filterRelationships(concept, { parent = true }) {
     const result = [];
     const relationships = concept.relationships;
     relationships.forEach((rel) => {
-        if (rel.active === true && (parent && rel.type.conceptId === IsASct) && (!parent && rel.type.conceptId !== IsASct)) {
+        if (rel.active === true && ((parent && rel.type.conceptId === IsASct) || (!parent && rel.type.conceptId !== IsASct))) {
             result.push({
                 conceptId: rel.destination.conceptId,
                 term: rel.destination.preferredTerm,
@@ -113,63 +114,62 @@ export async function getChildren(sctid, { all = false, completed = true, leaf =
     return result;
 }
 
-// "characteristicType.conceptId": "900000000000010007"
+export async function getConceptByExpression(expression, termSearch = null, form = 'stated', languageCode = 'es') {
+    const options = {
+        form
+    };
+    const query = makeMongoQuery(expression, options);
 
-export async function contextFilter(options) {
-    const conditions = {};
-    if (options.attributes) {
-        const attributes = options.attributes;
-        const conds = [];
-        for (const elem of attributes) {
-            const filters = {
-                active: true
-            };
-            if (elem.sctid) {
-                if (!elem.descendientes) {
-                    filters['destination.conceptId'] = elem.sctid;
-                } else {
-                    filters['destination.conceptId'] = {
-                        $in: await getChildren(elem.sctid, { all: true, completed: false })
-                    };
+    if (termSearch) {
+        const project = { fullySpecifiedName: 1, conceptId: 1, _id: false, semtag: 1 };
+
+        const conditions = [];
+        const words = termSearch.split(' ');
+        words.forEach((word) => {
+            word = word.replace(/([-()\[\]{}+?*.$\^|,:#<!\\])/g, '\\$1').replace(/\x08/g, '\\x08');
+            const expWord = '^' + utils.removeDiacritics(word) + '.*';
+            conditions.push({ 'descriptions.words': { $regex: expWord } });
+        });
+
+        const pipeline = [
+            {
+                $match: query,
+            },
+            {
+                $project: { ...project, descriptions: 1 }
+            },
+            {
+                $unwind: '$descriptions'
+            },
+            {
+                $match: {
+                    'descriptions.languageCode': languageCode,
+                    $and: conditions
+                }
+            },
+            {
+                $project: {
+                    fsn: '$fullySpecifiedName',
+                    term: '$descriptions.term',
+                    conceptId: '$conceptId',
+                    semanticTag: '$semtag'
                 }
             }
-            if (elem.typeid) {
-                filters['type.conceptId'] = elem.typeid;
-            }
-            conds.push(filters);
-        }
-        conditions['relationships'] = {
-            $elemMatch: conds
-        };
-    }
-
-    if (options.leaf) {
-        conditions['isLeafInferred'] = true;
-        conditions['isLeafStated'] = true;
-    }
-
-    if (options.childOf) {
-        conditions['$or'] = [
-            { inferredAncestors: options.childOf },
-            { statedAncestors: options.childOf }
         ];
+
+        return await SnomedModel.aggregate(pipeline);
+    } else {
+        const docs: any[] = await SnomedModel.find(query, { fullySpecifiedName: 1, conceptId: 1, _id: false, semtag: 1 }).sort({ fullySpecifiedName: 1 });
+        return docs.map((item) => {
+            const term = item.fullySpecifiedName.substring(0, item.fullySpecifiedName.indexOf('(') - 1);
+            return {
+                fsn: item.fullySpecifiedName,
+                term,
+                conceptId: item.conceptId,
+                semanticTag: item.semtag
+            };
+        });
     }
-
-    return SnomedModel.find(conditions);
-}
-
-export async function getConceptByExpression(expression) {
-    const query = makeMongoQuery(expression);
-    const docs: any[] = await SnomedModel.find(query, { fullySpecifiedName: 1, conceptId: 1, _id: false, semtag: 1 }).sort({ fullySpecifiedName: 1 });
-    return docs.map((item) => {
-        const term = item.fullySpecifiedName.substring(0, item.fullySpecifiedName.indexOf('(') - 1);
-        return {
-            fsn: item.fullySpecifiedName,
-            term,
-            conceptId: item.conceptId,
-            semanticTag: item.semtag
-        };
-    });
 }
 
 export async function getConcepts(conceptsIds) {
@@ -209,4 +209,53 @@ export async function getConcepts(conceptsIds) {
             }
         }
     ]);
+}
+
+
+export async function searchTerms(text, { semanticTags, languageCode }) {
+    const conditions = {
+        languageCode: 'spanish',
+        conceptActive: true,
+        active: true
+    };
+    // Filtramos por semanticTag
+    if (semanticTags && semanticTags.length > 0) {
+        conditions['$or'] = [...[], semanticTags].map((i) => { return { semanticTag: i }; });
+    }
+
+    // creamos un array de palabras a partir de la separacion del espacio
+    text = text.toLowerCase();
+    // Busca por palabras
+    conditions['$and'] = [];
+    const words = text.split(' ');
+    words.forEach((word) => {
+        // normalizamos cada una de las palabras como hace SNOMED para poder buscar palabra a palabra
+        word = word.replace(/([-()\[\]{}+?*.$\^|,:#<!\\])/g, '\\$1').replace(/\x08/g, '\\x08').replace('ñ', 'n');
+        const expWord = '^' + utils.removeDiacritics(word) + '.*';
+
+        // agregamos la palabra a la condicion
+        conditions['$and'].push({ words: { $regex: expWord } });
+    });
+
+
+    // preparamos query
+    const query = TextIndexModel.find(conditions, {
+        _id: 0,
+        conceptId: 1,
+        term: 1,
+        fsn: 1,
+        semanticTag: 1,
+        refsetIds: 1
+    });
+    query.limit(10000);
+    query.sort({ term: 1 });
+
+    let conceptos = await query;
+
+    conceptos = conceptos.filter((i: any) => i.term !== i.fsn);
+    return conceptos.sort((a: any, b: any) => {
+        if (a.term.length < b.term.length) { return -1; }
+        if (a.term.length > b.term.length) { return 1; }
+        return 0;
+    });
 }

--- a/core/term/controller/snomed.snowstorm.ts
+++ b/core/term/controller/snomed.snowstorm.ts
@@ -180,7 +180,7 @@ export async function getConceptByExpression(expression, term = null, form = 'st
 
 
 export async function searchTerms(text, { semanticTags, languageCode }, conceptIds: string[] = null) {
-    const textFold = utils.removeDiacritics(text);
+    const textFold = utils.removeDiacritics(text).replace(/[\u00F1]/g, 'n');
     const terms = textFold.split(' ');
     const searchStrig = terms.map(i => i + '*').join(' ');
     semanticTags = semanticTags || [];

--- a/core/term/controller/snomed.snowstorm.ts
+++ b/core/term/controller/snomed.snowstorm.ts
@@ -1,0 +1,418 @@
+import { Client } from 'elasticsearch';
+import { snomed, conSql } from '../../../config.private';
+import { handleHttpRequest } from '../../../utils/requestHandler';
+
+// ID del atributo que genera una relación padre-hijo
+const IsASct = '116680003';
+
+const snowstormClient = new Client({
+    host: snomed.snowstormElastic
+});
+
+async function httpGetSnowstorm(url: String, qs = {}) {
+    const [status, body] = await handleHttpRequest({
+        url: `${snomed.snowstormHost}/${url}`,
+        json: true,
+        useQuerystring: true,
+        headers: {
+            'Accept-Language': 'es'
+        },
+        qs
+    });
+    if (status === 200) {
+        return body;
+    }
+    return null;
+}
+
+function getSemanticTagFromFsn(fsn: String) {
+    const startAt = fsn.lastIndexOf('(');
+    const endAt = fsn.lastIndexOf(')');
+    return fsn.substring(startAt + 1, endAt);
+}
+
+/**
+ * Obtiene un objeto concepto a partir del conceptId
+ *
+ * @param sctid ConceptId
+ */
+
+export async function getConcept(sctid, format = 'full') {
+    const concept = await httpGetSnowstorm(`browser/${snomed.snowstormBranch}/concepts/${sctid}`);
+    if (concept) {
+        if (format === 'full') {
+            return concept;
+        } else {
+            return {
+                conceptId: concept.conceptId,
+                term: concept.pt.term,
+                fsn: concept.fsn.term,
+                semanticTag: getSemanticTagFromFsn(concept.fsn.term),
+                refsetIds: []
+            };
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Filtra las relaciones de un concepto
+ * [TODO] Filtros de atributos y también por estados (stated y inferred)
+ *
+ * @param {conceptMoldel} concept Concepto completo
+ */
+
+export function filterRelationships(concept, { parent = true }) {
+    const result = [];
+    const relationships = concept.relationships;
+    relationships.forEach((rel) => {
+        if (rel.active === true && ((parent && rel.typeId === IsASct) || (!parent && rel.typeId !== IsASct))) {
+            result.push({
+                conceptId: rel.target.conceptId,
+                term: rel.target.preferredTerm,
+                fsn: rel.target.fullySpecifiedName,
+                type: rel.characteristicType.conceptId === 'INFERRED_RELATIONSHIP' ? 'inferred' : 'stated'
+            });
+        }
+    });
+    return result;
+}
+
+/**
+ * Obtiene los hijos de un concepto
+ *
+ * @param sctid ConceptId
+ * @param {Boolean} all True para devolver hijos, nietos, bisnietos... de un concepto, false solo hijos directos.
+ *
+ */
+export async function getChildren(sctid, { all = false, completed = true, leaf = false }) {
+    let concepts;
+    if (all) {
+        const response = await httpGetSnowstorm(`${snomed.snowstormBranch}/concepts/${sctid}/descendants`, { limit: 1000, stated: false });
+        if (response) {
+            concepts = response.items;
+        }
+    } else {
+        const response = await httpGetSnowstorm(`browser/${snomed.snowstormBranch}/concepts/${sctid}/children`, { limit: 1000, form: 'inferred' });
+        if (response) {
+            concepts = response;
+        }
+    }
+    if (concepts) {
+        const result = [];
+        concepts.forEach((cpt) => {
+            if (cpt.active === true) {
+                if (completed) {
+                    result.push({
+                        conceptId: cpt.conceptId,
+                        term: cpt.pt.term,
+                        fsn: cpt.fsn.term,
+                        semanticTag: getSemanticTagFromFsn(cpt.fsn.term),
+                        refsetIds: []
+                    });
+                } else {
+                    result.push(cpt.conceptId);
+                }
+            }
+        });
+        return result;
+    }
+    return null;
+}
+
+export async function getConcepts(conceptsIds: string[]) {
+    const response = await httpGetSnowstorm(`${snomed.snowstormBranch}/concepts`, {
+        limit: 1000,
+        conceptIds: conceptsIds
+    });
+    if (response) {
+        const items = response.items;
+        const ps = items.map(async (concept) => {
+            const parents = await httpGetSnowstorm(`browser/${snomed.snowstormBranch}/concepts/${concept.conceptId}/parents`, { limit: 1000, form: 'stated' });
+            if (parents) {
+                concept.relationships = parents;
+                concept.relationships = filterRelationships(concept, { parent: true });
+            }
+            return {
+                conceptId: concept.conceptId,
+                term: concept.pt.term,
+                fsn: concept.fsn.term,
+                semanticTag: getSemanticTagFromFsn(concept.fsn.term),
+                refsetIds: [],
+                relationships: concept.relationships
+            };
+        });
+        return await Promise.all(ps);
+    }
+    return null;
+}
+
+export async function getConceptByExpression(expression, term = null, form = 'stated', languageCode = 'es') {
+    const qs: any = {
+        limit: 10000,
+        termActive: true,
+        term
+    };
+    if (form === 'stated') {
+        qs.statedEcl = expression;
+    } else {
+        qs.ecl = expression;
+    }
+    const response = await httpGetSnowstorm(`${snomed.snowstormBranch}/concepts`, qs);
+    if (response) {
+        const items = response.items;
+        const ps = items.map((concept) => {
+            return {
+                conceptId: concept.conceptId,
+                term: concept.pt.term,
+                fsn: concept.fsn.term,
+                semanticTag: getSemanticTagFromFsn(concept.fsn.term),
+                refsetIds: [],
+            };
+        });
+        return ps;
+    }
+    return null;
+}
+
+
+export async function searchTerms(text, { semanticTags, languageCode }) {
+    const terms = text.split(' ');
+    const searchStrig = terms.map(i => i + '*').join(' ');
+    semanticTags = semanticTags || [];
+    languageCode = languageCode || 'es';
+
+    const searchResult = await snowstormClient.search({
+        index: 'description',
+        type: 'description',
+        size: '10000',
+        body: {
+            query: {
+                bool: {
+                    must: [
+                        {
+                            term: {
+                                languageCode: {
+                                    value: languageCode,
+                                    boost: 1.0
+                                }
+                            }
+                        }
+                    ],
+                    filter: [
+                        {
+                            simple_query_string: {
+                                query: searchStrig,
+                                fields: [
+                                    'termFolded^1.0'
+                                ],
+                                flags: -1,
+                                default_operator: 'and',
+                                analyze_wildcard: false,
+                                auto_generate_synonyms_phrase_query: true,
+                                fuzzy_prefix_length: 0,
+                                fuzzy_max_expansions: 50,
+                                fuzzy_transpositions: true,
+                                boost: 1.0
+                            }
+                        }
+                    ],
+                    adjust_pure_negative: true,
+                    boost: 1.0
+                }
+            },
+            stored_fields: [
+                'descriptionId',
+                'conceptId'
+            ],
+            sort: [
+                {
+                    termLen: {
+                        order: 'asc'
+                    }
+                },
+                {
+                    _score: {
+                        order: 'asc'
+                    }
+                }
+            ]
+        }
+    });
+    const ids = searchResult.hits.hits.map(item => item.fields.conceptId[0]);
+
+    const searchResult2 = await snowstormClient.search({
+        index: 'description',
+        type: 'description',
+        size: '10000',
+        body: {
+            query: {
+                bool: {
+                    must: [
+                        {
+                            bool: {
+                                should: semanticTags.map(value => ({ term: { tag: value } }))
+                            }
+                        },
+                        {
+                            term: {
+                                languageCode: {
+                                    value: languageCode,
+                                    boost: 1.0
+                                }
+                            }
+                        },
+                        {
+                            terms: {
+                                active: [
+                                    true
+                                ],
+                                boost: 1.0
+                            }
+                        },
+                        {
+                            terms: {
+                                typeId: [
+                                    '900000000000003001'
+                                ],
+                                boost: 1.0
+                            }
+                        },
+                        {
+                            terms: {
+                                conceptId: ids,
+                                boost: 1.0
+                            }
+                        }
+                    ],
+                    adjust_pure_negative: true,
+                    boost: 1.0
+                }
+            },
+            _source: {
+                includes: [
+                    'conceptId',
+                    'term',
+                    'tag'
+                ],
+                excludes: []
+            }
+        }
+    });
+
+    const realConcept = searchResult2.hits.hits.map(item => {
+        return {
+            conceptId: item._source.conceptId,
+            fsn: item._source.term,
+            semanticTag: item._source.tag
+        };
+    });
+
+
+    const searchResult3 = await snowstormClient.search({
+        index: 'description',
+        type: 'description',
+        size: '10000',
+        body: {
+            query: {
+                bool: {
+                    must: [
+                        {
+                            term: {
+                                languageCode: {
+                                    value: languageCode,
+                                    boost: 1.0
+                                }
+                            }
+                        }
+                    ],
+                    must_not: [
+                        {
+                            terms: {
+                                typeId: [
+                                    '900000000000003001'
+                                ],
+                                boost: 1.0
+                            }
+                        }
+                    ],
+                    filter: [
+                        {
+                            simple_query_string: {
+                                query: searchStrig,
+                                fields: [
+                                    'termFolded^1.0'
+                                ],
+                                flags: -1,
+                                default_operator: 'and',
+                                analyze_wildcard: false,
+                                auto_generate_synonyms_phrase_query: true,
+                                fuzzy_prefix_length: 0,
+                                fuzzy_max_expansions: 50,
+                                fuzzy_transpositions: true,
+                                boost: 1.0
+                            }
+                        },
+                        {
+                            bool: {
+                                must: [
+                                    {
+                                        terms: {
+                                            conceptId: realConcept.map(i => i.conceptId),
+                                            boost: 1.0
+                                        }
+                                    }
+                                ],
+                                adjust_pure_negative: true,
+                                boost: 1.0
+                            }
+                        },
+                        {
+                            terms: {
+                                active: [
+                                    true
+                                ],
+                                boost: 1.0
+                            }
+                        },
+                    ],
+                    adjust_pure_negative: true,
+                    boost: 1.0
+                },
+            },
+            _source: {
+                includes: [
+                    'conceptId',
+                    'term'
+                ]
+            },
+            sort: [
+                {
+                    termLen: {
+                        order: 'asc'
+                    }
+                },
+                {
+                    _score: {
+                        order: 'asc'
+                    }
+                }
+            ],
+        }
+    });
+    const hash = {};
+    realConcept.forEach(i => hash[i.conceptId] = i);
+    return searchResult3.hits.hits.map(a => {
+        return {
+            ...hash[a._source.conceptId],
+            term: a._source.term,
+            refsetIds: []
+        };
+    }).sort((a: any, b: any) => {
+        if (a.term.length < b.term.length) { return -1; }
+        if (a.term.length > b.term.length) { return 1; }
+        return 0;
+    });
+
+}

--- a/core/term/routes/snomedv2.ts
+++ b/core/term/routes/snomedv2.ts
@@ -1,10 +1,5 @@
 import * as express from 'express';
-import { TextIndexModel, SnomedModel } from '../schemas/snomed';
-import * as utils from '../../../utils/utils';
-import * as SnomedCtr from '../controller/snomedCtr';
-import * as configPrivate from './../../../config.private';
-import { makeMongoQuery } from '../controller/grammar/parser';
-import { toArray } from '../../../utils/utils';
+import { SnomedCtr } from '../controller/snomed.controller';
 
 const router = express.Router();
 
@@ -28,7 +23,7 @@ router.get('/snomed/concepts/:sctid', async (req, res, next) => {
  */
 
 router.get('/snomed/concepts', async (req, res, next) => {
-    const sctids =  Array.isArray(req.query.sctids) ? req.query.sctids : [req.query.sctids];
+    const sctids = Array.isArray(req.query.sctids) ? req.query.sctids : [req.query.sctids];
     try {
         const concepts = await SnomedCtr.getConcepts(sctids);
         return res.json(concepts);
@@ -53,6 +48,7 @@ router.get('/snomed/concepts/:sctid/descriptions', async (req, res, next) => {
 
 /**
  * Devuelve los padres de un concepto
+ * [DEPRECATED]
  */
 
 router.get('/snomed/concepts/:sctid/parents', async (req, res, next) => {
@@ -74,6 +70,7 @@ router.get('/snomed/concepts/:sctid/parents', async (req, res, next) => {
  * @param {Boolean} all True para devolver todo el arbol abajo del concept ID
  * @param {Boolean} leaf Devulve solo los descencientes hojas
  *
+ * [DEPRECATED] No se usa desde la app
  */
 
 router.get('/snomed/concepts/:sctid/childs', async (req, res, next) => {
@@ -89,192 +86,13 @@ router.get('/snomed/concepts/:sctid/childs', async (req, res, next) => {
     }
 });
 
-/**
- * Busqueda de concepto snomed
- * Filtro por texto, reference set, semanticTag, Atributos, Hojas.
- * Skip y limit
- */
-router.get('/snomed/search', async (req, res, next) => {
-    if (!req.query.search && !req.query.refsetId && req.query.search !== '') {
-        return next('Debe ingresar un parámetro de búsqueda');
-    }
-
-    const search = req.query.search;
-
-    // Filtros básicos
-    const conditions = {
-        languageCode: 'spanish',
-        conceptActive: true,
-        active: true
-    };
-
-    // Filtramos por semanticTag
-    if (req.query.semanticTag) {
-        conditions['$or'] = req.query.semanticTag.map((i) => { return { semanticTag: i }; });
-    }
-
-    // Filtro por referen set
-    if (req.query.refsetId) {
-        conditions['refsetIds'] = req.query.refsetId;
-    }
-
-    if (isNaN(search)) {
-        // Busca por palabras
-        conditions['$and'] = [];
-        const words = search.split(' ');
-        words.forEach((word) => {
-            // normalizamos cada una de las palabras como hace SNOMED para poder buscar palabra a palabra
-            word = word.replace(/([-()\[\]{}+?*.$\^|,:#<!\\])/g, '\\$1').replace(/\x08/g, '\\x08');
-            const expWord = '^' + utils.removeDiacritics(word) + '.*';
-            // agregamos la palabra a la condicion
-            conditions['$and'].push({ words: { $regex: expWord } });
-        });
-    } else {
-        // Busca por conceptId
-        conditions['conceptId'] = search.toString();
-    }
-
-    let lookUp = null;
-    const secondMatch = { $match: {} };
-    const attributes = req.query.attributes;
-    const leaf = req.query.leaf;
-    if (attributes || leaf) {
-        lookUp = {
-            $lookup: {
-                from: configPrivate.snomed.dbVersion,
-                localField: 'conceptId',
-                foreignField: 'conceptId',
-                as: 'concept'
-            }
-        };
-    }
-
-    // Filtros por atributos
-    if (attributes) {
-        const conds = [];
-        for (const elem of attributes) {
-            const filters = {
-                active: true
-            };
-            if (elem.sctid) {
-                if (!elem.descendientes) {
-                    filters['destination.conceptId'] = elem.sctid;
-                } else {
-                    filters['destination.conceptId'] = {
-                        $in: await SnomedCtr.getChildren(elem.sctid, { all: true, completed: false })
-                    };
-                }
-            }
-            if (elem.typeid) {
-                filters['type.conceptId'] = elem.typeid;
-            }
-            const cond = {
-                'concept.relationships': {
-                    $elemMatch: filters
-                }
-            };
-            conds.push(cond);
-        }
-        secondMatch['$match']['$and'] = conds;
-    }
-
-    // Filtrams solo las hojas.
-    if (leaf) {
-        secondMatch['$match']['concept.isLeafInferred'] = true;
-        secondMatch['$match']['concept.isLeafStated'] = true;
-    }
-
-    const pipeline = [
-        { $match: conditions },
-
-        ...(lookUp ? [lookUp, secondMatch] : []),
-        // ...(secondMatch ? [lookUp, secondMatch] : []),
-
-        { $sort: { term: 1 } },
-        { $skip: parseInt(req.query.skip, 0) || 0 },
-        { $limit: parseInt(req.query.limit, 0) || 1000 },
-        {
-            $project: {
-                conceptId: 1,
-                term: 1,
-                fsn: 1,
-                semanticTag: 1,
-                refsetIds: 1,
-                aEq: { $eq: ['$fsn', '$term'] }
-            }
-        },
-        { $match: { aEq: false } }
-    ];
-
-    const result = await toArray(TextIndexModel.aggregate(pipeline).cursor({}).exec());
-    res.send(result);
-
-});
-
 router.get('/snomed/expression', async (req, res, next) => {
-    let options = {
-        form: req.query.type || 'stated'
-    };
+    const form = req.query.type || 'stated';
+    const words = req.query.words;
+    const expression = req.query.expression;
+    const languageCode = req.query.languageCode ? req.query.languageCode : 'es';
 
-    let expression = req.query.expression;
-    let query = makeMongoQuery(expression, options);
-    let project = { fullySpecifiedName: 1, conceptId: 1, _id: false, semtag: 1 };
-    let languageCode = req.query.languageCode ? req.query.languageCode : 'es';
-
-    if (req.query.field && req.query.field === 'term') {
-
-        let conditions = [];
-        let words = req.query.words.split(' ');
-        words.forEach((word) => {
-            // normalizamos cada una de las palabras como hace SNOMED para poder buscar palabra a palabra
-            word = word.replace(/([-()\[\]{}+?*.$\^|,:#<!\\])/g, '\\$1').replace(/\x08/g, '\\x08');
-            let expWord = '^' + utils.removeDiacritics(word) + '.*';
-            // agregamos la palabra a la condicion
-            conditions.push({ 'descriptions.words': { $regex: expWord } });
-        });
-
-        const pipeline = [
-            {
-                $match: query,
-            },
-            {
-                $project: { ...project, descriptions: 1 }
-            },
-            {
-                $unwind: '$descriptions'
-            },
-            {
-                $match: {
-                    'descriptions.languageCode': languageCode,
-                    $and: conditions
-                }
-            },
-            {
-                $project: {
-                    fsn: '$fullySpecifiedName',
-                    term: '$descriptions.term',
-                    conceptId: '$conceptId',
-                    semanticTag: '$semtag'
-                }
-            }
-        ];
-
-        res.json(await toArray(SnomedModel.aggregate(pipeline).cursor({}).exec()));
-
-    } else {
-
-        SnomedModel.find(query, { fullySpecifiedName: 1, conceptId: 1, _id: false, semtag: 1 }).sort({ fullySpecifiedName: 1 }).then((docs: any[]) => {
-            const response = docs.map((item) => {
-                const term = item.fullySpecifiedName.substring(0, item.fullySpecifiedName.indexOf('(') - 1);
-                return {
-                    fsn: item.fullySpecifiedName,
-                    term,
-                    conceptId: item.conceptId,
-                    semanticTag: item.semtag
-                };
-            });
-            return res.json(response);
-        }).catch(next);
-    }
+    const concepts = await SnomedCtr.getConceptByExpression(expression, words, form, languageCode);
+    return res.json(concepts);
 });
 export = router;

--- a/core/term/schemas/snomed.ts
+++ b/core/term/schemas/snomed.ts
@@ -11,10 +11,10 @@ export let TextIndexSchema = new mongoose.Schema({
 });
 
 // Se asegura que los índices estén creados
-TextIndexSchema.index({ descriptionId: 1});
-TextIndexSchema.index({ term: 'text'});
-TextIndexSchema.index({ term: 1});
-TextIndexSchema.index({ words: 1});
+TextIndexSchema.index({ descriptionId: 1 });
+TextIndexSchema.index({ term: 'text' });
+TextIndexSchema.index({ term: 1 });
+TextIndexSchema.index({ words: 1 });
 
 // textIndexSchema.index({ words: 1, semanticTag: 1, languageCode: 1, conceptActive: 1, active: 1 });
 // textIndexSchema.index({ conceptId: 1, semanticTag: 1, languageCode: 1, conceptActive: 1, active: 1 });
@@ -41,10 +41,12 @@ export let SnomedSchema = new mongoose.Schema({
     relationships: [{
         _id: false,
         active: Boolean,
-        type: {type: {
-            conceptId: String,
-            preferredTerm: String
-        }},
+        type: {
+            type: {
+                conceptId: String,
+                preferredTerm: String
+            }
+        },
         destination: {
             conceptId: String,
             fullySpecifiedName: String,
@@ -64,12 +66,12 @@ export let SnomedSchema = new mongoose.Schema({
     }]
 });
 
-SnomedSchema.index({conceptId : 1});
-SnomedSchema.index({'relationships.destination.conceptId' : 1, 'relationships.type.conceptId' : 1});
-SnomedSchema.index({'relationships.type.conceptId' : 1, 'relationships.destination.conceptId' : 1});
-SnomedSchema.index({inferredAncestors : 1});
-SnomedSchema.index({statedAncestors : 1});
-SnomedSchema.index({'memberships.refset.conceptId': 1});
+SnomedSchema.index({ conceptId: 1 });
+SnomedSchema.index({ 'relationships.destination.conceptId': 1, 'relationships.type.conceptId': 1 });
+SnomedSchema.index({ 'relationships.type.conceptId': 1, 'relationships.destination.conceptId': 1 });
+SnomedSchema.index({ inferredAncestors: 1 });
+SnomedSchema.index({ statedAncestors: 1 });
+SnomedSchema.index({ 'memberships.refset.conceptId': 1 });
 
 
 export let SnomedModel = Connections.snomed.model(configPrivate.snomed.dbName, SnomedSchema, configPrivate.snomed.dbVersion);

--- a/modules/descargas/controller/descargas.ts
+++ b/modules/descargas/controller/descargas.ts
@@ -8,7 +8,7 @@ import { Auth } from '../../../auth/auth.class';
 import { model as Prestacion } from '../../rup/schemas/prestacion';
 import * as Paciente from '../../../core/mpi/controller/paciente';
 import { Organizacion } from '../../../core/tm/schemas/organizacion';
-import * as snomed from '../../../core/term/controller/snomedCtr';
+import { SnomedCtr } from '../../../core/term/controller/snomed.controller';
 import * as rup from '../../../modules/rup/schemas/elementoRUP';
 import * as conceptoTurneable from '../../../core/tm/schemas/tipoPrestacion';
 import * as path from 'path';
@@ -466,7 +466,7 @@ export class Documento {
                     }
 
                     // Vemos si el tipo de prestación tiene registros que son hijos directos (TP: Ecografía; Hijo: Ecografía obstétrica)
-                    let hijos = await snomed.getChildren(prestacion.solicitud.tipoPrestacion.conceptId, { all: true });
+                    let hijos = await SnomedCtr.getChildren(prestacion.solicitud.tipoPrestacion.conceptId, { all: true });
                     let motivoPrincipalDeConsulta;
                     let tituloRegistro;
                     let contenidoInforme;

--- a/modules/rup/controllers/plantillasRUP.ts
+++ b/modules/rup/controllers/plantillasRUP.ts
@@ -1,5 +1,5 @@
 import { PlantillasRUP } from '../schemas/plantillasRUP';
-import { getConceptByExpression } from '../../../core/term/controller/snomedCtr';
+import { SnomedCtr } from '../../../core/term/controller/snomed.controller';
 import { Auth } from '../../../auth/auth.class';
 import { Types } from 'mongoose';
 const ObjectId = Types.ObjectId;
@@ -8,7 +8,7 @@ export async function create(data, req) {
     // [TODO] implementar permisos especiales para crear elementos Globales o no.
     const expression = data.expression;
 
-    const conceptos = await getConceptByExpression(expression);
+    const conceptos = await SnomedCtr.getConceptByExpression(expression);
     data.conceptos = conceptos;
 
     const plantilla = new PlantillasRUP(data);
@@ -21,7 +21,7 @@ export async function update(id, data, req) {
     if (plantilla) {
 
         const expression = data.expression;
-        const conceptos = await getConceptByExpression(expression);
+        const conceptos = await SnomedCtr.getConceptByExpression(expression);
         data.conceptos = conceptos;
 
         plantilla.set(data);

--- a/modules/rup/routes/elementosRUP.ts
+++ b/modules/rup/routes/elementosRUP.ts
@@ -19,6 +19,7 @@ router.get('/elementosRUP/:id/guiada', async (req, res, next) => {
         let flag = false;
         for (const guia of elemento.busqueda_guiada) {
             if (!guia.conceptIds.length) {
+                flag = true;
                 guia.conceptIds = await SnomedCtr.getConceptByExpression(guia.query);
                 guia.conceptIds = guia.conceptIds.map(c => c.conceptId);
             }

--- a/utils/requestHandler.ts
+++ b/utils/requestHandler.ts
@@ -16,7 +16,7 @@ export function handleHttpRequest(params): Promise<any> {
     return new Promise((resolve, reject) => {
         request(params, (err, response, body) => {
             if (!err) {
-                let status = response && response.statusCode;
+                const status = response && response.statusCode;
                 return resolve([status, body]);
             } else {
                 return reject(err);


### PR DESCRIPTION
### Requerimiento
Actualizar a las nuevas APIs y bases de SNOMED. Soportar Snowstorm.

### Funcionalidad desarrollada 
1. Se generan las mismas consultas que se hacían en mongo, vía snowstorm.
2. Se mantienen las interfaces para evitar cambios.
3. Mantiene las dos implementaciones para hacer una prueba incremental.
4. Agrega nueva configuraciones al config.private.

### UserStories llegó a completarse
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [ ] Si
- [ ] No
- Requiere una nueva base de datos: [snowstorm](https://github.com/IHTSDO/snowstorm)