### PR TITLE
fix(carpetas): ruta de carpeta devolvia null

### DIFF
--- a/modules/carpetas/controller/carpetaPacienteController.ts
+++ b/modules/carpetas/controller/carpetaPacienteController.ts
@@ -8,6 +8,8 @@ export async function buscarCarpeta(req) {
         if (req.query.documento && req.query.organizacion) {
             carpeta = carpetaPaciente.find({ documento: req.query.documento });
             carpeta.where('carpetaEfectores.organizacion._id').equals(req.query.organizacion);
+        } else {
+            return [];
         }
     }
     return await carpeta;


### PR DESCRIPTION
### Requerimiento
La ruta getCarpetasPAciente estaba devolviendo null cuando el paciente no tenía documento. Debe devolver array vacío como si no encontro carpetas. 

### Funcionalidad desarrollada 
1.  Se agrego un else necesario


### UserStories llegó a completarse 
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No

 