### PR TITLE
fix(descarga procedimientos): se devuelve if desaparecido

### DIFF
--- a/modules/descargas/controller/descargas.ts
+++ b/modules/descargas/controller/descargas.ts
@@ -513,8 +513,12 @@ export class Documento {
                             break;
                     }
 
-                    // SE ARMA TODO EL HTML PARA GENERAR EL PDF:
-                    await this.generarInforme(registros);
+                    if (!registro) {
+                        // SE ARMA TODO EL HTML PARA GENERAR EL PDF:
+                        await this.generarInforme(registros);
+                    } else {
+                        await this.generarInforme([registro]);
+                    }
 
 
                     // Si no hay configuración de informe o si se configura "registrosDefault" en true, se genera el informe por defecto (default)


### PR DESCRIPTION
Requerimiento
Al mergear el PR #752 se perdió parte del código, este PR lo devuelve.

### Funcionalidad desarrollada 
1. Se reinserta el código, no se llegó a ninguna conclusión luego de revisar este tema con @liquid36 :joy_cat: 

```
if (!registro) {
    let registros = prestacion.ejecucion.registros[0].registros.length ? prestacion.ejecucion.registros[0].registros : prestacion.ejecucion.registros;
    // SE ARMA TODO EL HTML PARA GENERAR EL PDF:
    await this.generarInforme(registros);
} else {
    await this.generarInforme([registro]);
}
```

### UserStories llegó a completarse
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [X] No
