### PR TITLE
CITAS: Se guarda organizacion y concepto snomed en prestacion

### DIFF
--- a/modules/turnos/routes/listaEspera.ts
+++ b/modules/turnos/routes/listaEspera.ts
@@ -1,14 +1,10 @@
 import * as express from 'express';
 import * as listaEspera from '../schemas/listaEspera';
-import { model as Prestacion } from '../../../modules/rup/schemas/prestacion';
 import * as agenda from '../schemas/agenda';
 import * as utils from '../../../utils/utils';
 import { defaultLimit, maxLimit } from './../../../config';
-// import * as config from '../../../config';
 import * as moment from 'moment';
 import { Logger } from '../../../utils/logService';
-import { Auth } from '../../../auth/auth.class';
-import { SnomedModel } from '../../../core/term/schemas/snomed';
 
 const async = require('async');
 const router = express.Router();
@@ -67,27 +63,6 @@ router.post('/listaEspera', async (req, res, next) => {
         });
         res.json(newItem);
     });
-    const prest: any = await SnomedModel.findOne({ conceptId: 419069000 });
-    const date = new Date();
-    const newPrestacion = new Prestacion({
-        paciente: req.body.paciente,
-        solicitud: {
-            fecha: date,
-            tipoPrestacion: {
-                id: prest._id,
-                conceptId: prest.conceptId,
-                term: prest.preferredTerm,
-                fsn: prest.fullySpecifiedName,
-                semanticTag: prest.semtag
-            }
-        },
-        estados: {
-            fecha: date,
-            tipo: 'rechazada'
-        }
-    });
-    Auth.audit(newPrestacion, req);
-    await newPrestacion.save();
 });
 
 router.put('/listaEspera/:_id', (req, res, next) => {

--- a/modules/turnos/routes/listaEspera.ts
+++ b/modules/turnos/routes/listaEspera.ts
@@ -8,7 +8,7 @@ import { defaultLimit, maxLimit } from './../../../config';
 import * as moment from 'moment';
 import { Logger } from '../../../utils/logService';
 import { Auth } from '../../../auth/auth.class';
-import { SnomedModel } from '../../../../api/core/term/schemas/snomed';
+import { SnomedModel } from '../../../core/term/schemas/snomed';
 
 const async = require('async');
 const router = express.Router();

--- a/modules/turnos/routes/listaEspera.ts
+++ b/modules/turnos/routes/listaEspera.ts
@@ -65,7 +65,7 @@ router.post('/listaEspera', async (req, res, next) => {
     });
 });
 
-router.put('/listaEspera/:_id', (req, res, next) => {
+router.put('/listaEspera/:id', (req, res, next) => {
     listaEspera.findByIdAndUpdate(req.params._id, req.body, { new: true }, (err, data) => {
         if (err) {
             return next(err);
@@ -75,7 +75,7 @@ router.put('/listaEspera/:_id', (req, res, next) => {
 });
 
 /*Si viene un id es porque se están enviando pacientes a la lista de espera desde una agenda suspendida*/
-router.post('/listaEspera/IdAgenda/:_id', (req, res, next) => {
+router.post('/listaEspera/IdAgenda/:id', (req, res, next) => {
     agenda.findById(req.params._id, (err, data) => {
         if (err) {
             return next(err);
@@ -105,7 +105,7 @@ router.post('/listaEspera/IdAgenda/:_id', (req, res, next) => {
 });
 
 
-router.delete('/listaEspera/:_id', (req, res, next) => {
+router.delete('/listaEspera/:id', (req, res, next) => {
     listaEspera.findByIdAndRemove(req.params._id, req.body, (err, data) => {
         if (err) { return next(err); }
         res.json(data);

--- a/modules/turnos/schemas/listaEspera.ts
+++ b/modules/turnos/schemas/listaEspera.ts
@@ -8,11 +8,15 @@ const listaEsperaSchema = new mongoose.Schema({
         apellido: String,
         documento: String
     },
-    tipoPrestacion: { type: tipoPrestacionSchema},
+    tipoPrestacion: { type: tipoPrestacionSchema },
     profesional: {
         id: mongoose.Schema.Types.ObjectId,
         nombre: String,
         apellido: String
+    },
+    organizacion: {
+        id: mongoose.Schema.Types.ObjectId,
+        nombre: String
     },
     fecha: Date, // si es una solicitud es la fecha en que se solicitó
     // si es demanda rechazada es la fecha en que no se atendió la demanda


### PR DESCRIPTION
### Requerimiento

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1.  Al rechazar una demanda en el punto de inicio, se guarda la organización logueada.
2.  Al rechazar una demanda en el punto de inicio, la prestacion seleccionada se guarda con el concepto snomed correspondiente
3.  Al rechazar una demanda en el punto de inicio, se crea una nueva prestacion en la BD con el Concepto Snomed  turno no disponible (hallazgo) SCTID: 419069000

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [X] No
