### PR TITLE
TURNERO: sumado tipo a turneroPantalla

### DIFF
--- a/auth/auth.class.ts
+++ b/auth/auth.class.ts
@@ -359,7 +359,7 @@ export class Auth {
      * @memberOf Auth
      */
 
-    static generateAppToken(user: any, organizacion: any, permisos: string[], type: 'app-token' | 'turnero-token' = 'app-token'): any {
+    static generateAppToken(user: any, organizacion: any, permisos: string[], type: 'app-token' | 'turnero-token' | 'totem-token' = 'app-token'): any {
         // Un token por organización. A futuro distintos permisos en la organización externa deberá modificarse esto!
         const token: AppToken = {
             id: mongoose.Types.ObjectId(),

--- a/modules/turnero/routes/configuracionPantalla.ts
+++ b/modules/turnero/routes/configuracionPantalla.ts
@@ -99,7 +99,6 @@ router.patch('/pantalla/:id', Auth.authenticate(), async (req, res, next) => {
         const id = req.params.id;
         const data = req.body;
         const pantalla = await TurneroPantalla.findByIdAndUpdate(id, data, { new: true });
-
         res.json(pantalla);
         EventCore.emitAsync('turnero-update', { pantalla });
         return;

--- a/modules/turnero/routes/configuracionPantalla.ts
+++ b/modules/turnero/routes/configuracionPantalla.ts
@@ -18,6 +18,9 @@ router.get('/pantalla', Auth.authenticate(), async (req: any, res, next) => {
         if (req.query.nombre) {
             opciones['nombre'] = req.query.nombre;
         }
+        if (req.query.tipo) {
+            opciones['tipo'] = req.query.tipo;
+        }
         let query = TurneroPantalla.find(opciones);
         if (req.query.fields) {
             query.select(req.query.fields);
@@ -120,8 +123,10 @@ router.delete('/pantalla/:id', Auth.authenticate(), async (req: any, res, next) 
 
 router.post('/pantalla/activate', async (req, res, next) => {
     let codigo = req.body.codigo;
+    let tipoPantalla = req.body.tipo;
     let pantallas = await TurneroPantalla.find({
         token: codigo,
+        tipo: tipoPantalla,
         expirationTime: { $gt: new Date() },
     });
     if (pantallas.length) {
@@ -129,13 +134,20 @@ router.post('/pantalla/activate', async (req, res, next) => {
         pantalla.token = null;
         pantalla.expirationTime = null;
         await pantalla.save();
-
-        let token = Auth.generateAppToken(pantalla, {}, [`turnero:${pantalla._id}`], 'turnero-token');
+        let token = '';
+        if (pantalla.tipo === 'totem') {
+            const organizacion = {
+                id: pantalla.organizacion,
+                nombre: 'totem'
+            };
+            token = Auth.generateAppToken(pantalla, organizacion, ['turnos:*', 'mpi:*'], 'totem-token');
+        } else {
+            token = Auth.generateAppToken(pantalla, {}, [`turnero:${pantalla._id}`], `turnero-token`);
+        }
         res.send({ token });
-
-        EventCore.emitAsync('turnero-activated', { pantalla });
+        EventCore.emitAsync(`${pantalla.tipo}-activated`, { pantalla });
     } else {
-        return next({ message: 'no eiste pantalla' });
+        return next({ message: 'no existe pantalla' });
     }
 });
 

--- a/modules/turnero/schemas/turneroPantalla.ts
+++ b/modules/turnero/schemas/turneroPantalla.ts
@@ -13,6 +13,7 @@ export interface IPantalla extends Document {
         }
     };
     playlist?: String;
+    bloqueada: Boolean;
 }
 
 export const TurneroPantallaSchema = new Schema({
@@ -27,6 +28,7 @@ export const TurneroPantallaSchema = new Schema({
         nombre: String
     }],
     playlist: { type: String, required: false },
+    bloqueada: Boolean
 });
 
 export const TurneroPantalla: Model<IPantalla> = model('turneroPantallas', TurneroPantallaSchema, 'turneroPantallas');

--- a/modules/turnero/schemas/turneroPantalla.ts
+++ b/modules/turnero/schemas/turneroPantalla.ts
@@ -2,6 +2,7 @@ import { model, Model, Types, SchemaTypes, Schema, Document } from 'mongoose';
 
 export interface IPantalla extends Document {
     nombre: String;
+    tipo: String;
     token: String;
     organizacion: Types.ObjectId;
     expirationTime: Date;
@@ -16,6 +17,7 @@ export interface IPantalla extends Document {
 
 export const TurneroPantallaSchema = new Schema({
     nombre: String,
+    tipo: String,
     token: { type: String, required: false },
     organizacion: SchemaTypes.ObjectId,
     expirationTime: Date,


### PR DESCRIPTION

### Requerimiento
Permitir configurar los totems de la misma forma que las pantallas del turnero. Se deberá especificar al cargar una nueva de qué tipo es (totem/turnero).

### Funcionalidad desarrollada 
1. Se sumó al schema de pantallaTurnero el campo tipo
2. Se modificó la ruta '/pantalla/activate' para recibir el tipo por parámetro

### UserStories llegó a completarse
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No
