### PR TITLE
CITAS: Agregar fecha, hora y usuario de dación de turno

### DIFF
--- a/modules/turnos/controller/agenda.ts
+++ b/modules/turnos/controller/agenda.ts
@@ -1063,6 +1063,7 @@ export function actualizarTurnosMobile() {
             localAddress: ''
         }
     };
+
     return cursor.eachAsync(async doc => {
         const agenda: any = doc;
         try {

--- a/modules/turnos/routes/turno.ts
+++ b/modules/turnos/routes/turno.ts
@@ -279,6 +279,8 @@ router.patch('/turno/:idTurno/bloque/:idBloque/agenda/:idAgenda/', async (req, r
         const etiquetaReasignado: string = 'bloques.' + posBloque + '.turnos.' + posTurno + '.reasignado';
         const etiquetaUpdateAt: string = 'bloques.' + posBloque + '.turnos.' + posTurno + '.updatedAt';
         const etiquetaUpdateBy: string = 'bloques.' + posBloque + '.turnos.' + posTurno + '.updatedBy';
+        const etiquetaUsuarioDacion: string = 'bloques.' + posBloque + '.turnos.' + posTurno + '.usuarioDacion';
+        const etiquetaFechHoraDacion: string = 'bloques.' + posBloque + '.turnos.' + posTurno + '.fechaHoraDacion';
 
         update[etiquetaEstado] = 'asignado';
         update[etiquetaPrestacion] = req.body.tipoPrestacion;
@@ -296,6 +298,8 @@ router.patch('/turno/:idTurno/bloque/:idBloque/agenda/:idAgenda/', async (req, r
         }
         update[etiquetaUpdateAt] = new Date();
         update[etiquetaUpdateBy] = usuario;
+        update[etiquetaUsuarioDacion] = usuario;
+        update[etiquetaFechHoraDacion] = new Date();
 
         const query = {
             _id: req.body.idAgenda,
@@ -322,7 +326,9 @@ router.patch('/turno/:idTurno/bloque/:idBloque/agenda/:idAgenda/', async (req, r
                     tipoTurno: update[etiquetaTipoTurno] !== null ? update[etiquetaTipoTurno] : null,
                     nota: update[etiquetaNota],
                     emitidoPor: update[etiquetaEmitidoPor], // agregamos el emitidoPor
-                    motivoConsulta: update[etiquetaMotivoConsulta]
+                    motivoConsulta: update[etiquetaMotivoConsulta],
+                    usuarioDacion: update[etiquetaUsuarioDacion],
+                    fechaHoraDacion: update[etiquetaFechHoraDacion]
                 };
 
                 // Se actualiza el campo financiador del paciente

--- a/modules/turnos/routes/turno.ts
+++ b/modules/turnos/routes/turno.ts
@@ -76,6 +76,7 @@ router.patch('/turno/agenda/:idAgenda', async (req, res, next) => {
         // Copia la organización desde el token
         usuario.organizacion = (req as any).user.organizacion;
         const tipoTurno = (esHoy ? 'delDia' : 'programado');
+        const fecha = new Date();
         const turno = {
             horaInicio: (agendaRes as any).horaInicio,
             estado: 'asignado',
@@ -84,8 +85,10 @@ router.patch('/turno/agenda/:idAgenda', async (req, res, next) => {
             motivoConsulta: req.body.motivoConsulta,
             paciente: req.body.paciente,
             tipoPrestacion: req.body.tipoPrestacion,
-            updatedAt: new Date(),
-            updatedBy: usuario
+            updatedAt: fecha,
+            updatedBy: usuario,
+            fechaHoraDacion: fecha,
+            usuarioDacion: usuario
         };
         const turnos = ((agendaRes as any).bloques[0].turnos);
         turnos.push(turno);

--- a/modules/turnos/schemas/turno.ts
+++ b/modules/turnos/schemas/turno.ts
@@ -102,7 +102,9 @@ const turnoSchema = new mongoose.Schema({
     },
     confirmedAt: Date, /* Confirmación del turno por el  paciente */
     updatedAt: Date,
-    updatedBy: mongoose.Schema.Types.Mixed
+    updatedBy: mongoose.Schema.Types.Mixed,
+    fechaHoraDacion: Date,
+    usuarioDacion: mongoose.Schema.Types.Mixed
 });
 
 export = turnoSchema;


### PR DESCRIPTION
### Requerimiento
[https://proyectos.andes.gob.ar/browse/CIT-25](url)

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se agregó al esquema turno los campos: fechaHoraDacion y UsuarioDacion para registrar la fecha/hora y el usuario que dio el turno.
2. Al crear el turno se guardan los nuevos campos.


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [X] No

