### PR TITLE
fix(rup): allowDisk en solicitudes

### DIFF
--- a/modules/rup/routes/prestacion.ts
+++ b/modules/rup/routes/prestacion.ts
@@ -325,7 +325,7 @@ router.get('/prestaciones/solicitudes', async (req, res, next) => {
             pipeline.push({ $limit: parseInt(req.query.limit, 10) });
         }
 
-        res.json(await Prestacion.aggregate(pipeline));
+        res.json(await Prestacion.aggregate(pipeline).allowDiskUse(true));
     } catch (err) {
         return next(404);
     }


### PR DESCRIPTION
### Requerimiento
<!-- URL de la User Story, referencia al issue (#1111) o breve descripcion del requerimiento -->
Agrega la opción de allow Disk en el get de solicitudes para solucionar el problema incidente del limite de uso de memoria ocasionado por el sort

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Agrega allowDisk true en Pipeline



### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
