### PR TITLE
fix(TOP): cambia el filtro de solicitudes por tipo de prestaciones

### DIFF
--- a/modules/rup/routes/prestacion.ts
+++ b/modules/rup/routes/prestacion.ts
@@ -279,8 +279,10 @@ router.get('/prestaciones/solicitudes', async (req, res, next) => {
         }
 
         if (req.query.tipoPrestaciones) {
-            match.$and.push({ 'solicitud.tipoPrestacion.id': { $in: req.query.tipoPrestaciones.map(e => Types.ObjectId(e)) } });
-            match.$and.push({ 'solicitud.tipoPrestacionOrigen.id': { $in: req.query.tipoPrestaciones.map(e => Types.ObjectId(e)) } });
+            match.$and.push({
+                $or: [{ 'solicitud.tipoPrestacion.id': { $in: req.query.tipoPrestaciones.map(e => Types.ObjectId(e)) } },
+                { 'solicitud.tipoPrestacionOrigen.id': { $in: req.query.tipoPrestaciones.map(e => Types.ObjectId(e)) } }]
+            });
         }
 
         pipeline.push({ $match: match });


### PR DESCRIPTION

### Requerimiento
BUG: en el modulo TOP cuando un usuario tiene permisos para visualizar solicitudes de algunos tipos de prestaciones se están filtrando aquella que tenga algún tipo de prestación permitida en origen **Y** en destino (debería ser en origen **O** en destino)


### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Corrige el filtro en el aggregate que ejecuta la api de solicitudes
2. 
3. 


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [] Si
- [] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
