### PR TITLE
RUP:Fecha de ejecución en agendas anteriores

### DIFF
--- a/modules/turnos/controller/agenda.ts
+++ b/modules/turnos/controller/agenda.ts
@@ -21,9 +21,12 @@ import { Types } from 'mongoose';
 export function darAsistencia(req, data, tid = null) {
     const turno = getTurno(req, data, tid);
     turno.asistencia = 'asistio';
-
     if (!turno.horaAsistencia) {
-        turno.horaAsistencia = new Date();
+        if (moment(turno.horaInicio).format('YYYY-MM-DD') < moment().startOf('day').format('YYYY-MM-DD')) {
+            turno.horaAsistencia = turno.horaInicio; // Para el caso donde se inicia una prestacion de un turno con fecha anterior a hoy
+        } else {
+            turno.horaAsistencia = new Date();
+        }
     }
 
     turno.updatedAt = new Date();


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/RUP-39

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Al registrar una asistencia se verifica en primer lugar si tiene registro de asistencia, en caso de no tenerlo y que el turno sea de un día anterior al actual, se le asigna como horario de asistencia, la hora de inicio de la agenda



### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No

