### PR TITLE
CITAS - Validación de profesional sobre efector al crear una agenda

### DIFF
--- a/core/tm/routes/profesional.ts
+++ b/core/tm/routes/profesional.ts
@@ -683,6 +683,7 @@ router.get('/profesionales/:id*?', Auth.authenticate(), async (req, res, next) =
                 for (let i = 0; i < data.length; i++) {
                     let prof = {};
 
+                    prof['nombre'] = data[i].nombre;
                     prof['apellido'] = data[i].apellido;
                     prof['tipoDocumento'] = data[i].tipoDocumento;
                     prof['documento'] = data[i].documento;


### PR DESCRIPTION

<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento

**CITAS - Validación de profesional sobre efector al crear una agenda**
Se presenta la problemática de que: Al no haber una validación para sobre el profesional al que se le esté creando una agenda de atención, es posible crearle una agenda incluso si esta persona no tiene agregado el lugar de origen como organización.

Para ello se procede a modificar la API y al momento de solicitar los profesionales (desde al APP) a los cuales se les creará una nueva agenda de atención, se realiza una comprobación para saber si el mismo tiene asignada la organización de origen. 
Esto resuelve que se cree una agenda para una persona equivocada en una organización y bloquee la creación de agendas sobre la organización validada. 


### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Validacion en metodo que devuelve profesionales
2. 
3. 


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [X ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
