### PR TITLE
APP-MOBILE: Fix confirmar turno luego de que una agenda se pausa

### DIFF
--- a/modules/turnos/routes/turno.ts
+++ b/modules/turnos/routes/turno.ts
@@ -163,7 +163,10 @@ router.patch('/turno/:idTurno/bloque/:idBloque/agenda/:idAgenda/', async (req, r
     const continues = ValidateDarTurno.checkTurno(req.body);
     const pacienteTurno = req.body.paciente;
     if (continues.valid) {
-        let agendaRes = await getAgenda(req.body.idAgenda);
+        let agendaRes: any = await getAgenda(req.body.idAgenda);
+        if (agendaRes.estado === 'pausada' || agendaRes.estado === 'suspendida') {
+            return next('La agenda ya no está disponible');
+        }
         try {
             let user = (req as any).user;
             if (user.organizacion) {


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/AM-35

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Antes de confirmar un turno, verifica que el estado de la agenda no haya cambiado en el transcurso de la solicitud a 'suspendida' o 'pausada'. Si esto pasa retorna un error.

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No
