### PR TITLE
APP-MOBILE: No actualiza el cupo al liberar turno cuando es el último disponible

### DIFF
--- a/modules/turnos/controller/agenda.ts
+++ b/modules/turnos/controller/agenda.ts
@@ -103,7 +103,6 @@ export async function liberarTurno(req, data, turno) {
         turno.reasignado = undefined;  // Esto es necesario cuando se libera un turno reasignado
         turno.updatedAt = new Date();
         turno.updatedBy = req.user.usuario || req.user;
-        turno.emitidoPor = ''; // Blanqueamos el emitido por (VER SI LO DEJAMOS O LO BLANQUEAMOS CUANDO EL PACIENTE LO ELIMINA)
         let cant = 1;
 
         const turnoDoble = getTurnoSiguiente(req, data, turno._id);
@@ -123,9 +122,10 @@ export async function liberarTurno(req, data, turno) {
                 break;
             case ('programado'):
                 data.bloques[position.indexBloque].restantesProgramados = data.bloques[position.indexBloque].restantesProgramados + cant;
-                if (data.bloques[position.indexBloque].restantesMobile) {
+                if (turno.emitidoPor === 'appMobile') {
                     data.bloques[position.indexBloque].restantesMobile = data.bloques[position.indexBloque].restantesMobile + cant;
                 }
+                turno.emitidoPor = ''; // Blanqueamos el emitido por (VER SI LO DEJAMOS O LO BLANQUEAMOS CUANDO EL PACIENTE LO ELIMINA)
                 break;
             case ('profesional'):
                 data.bloques[position.indexBloque].restantesProfesional = data.bloques[position.indexBloque].restantesProfesional + cant;

--- a/modules/turnos/controller/agenda.ts
+++ b/modules/turnos/controller/agenda.ts
@@ -122,7 +122,7 @@ export async function liberarTurno(req, data, turno) {
                 break;
             case ('programado'):
                 data.bloques[position.indexBloque].restantesProgramados = data.bloques[position.indexBloque].restantesProgramados + cant;
-                if (turno.emitidoPor === 'appMobile') {
+                if (this.esVirtual(turno.emitidoPor)) {
                     data.bloques[position.indexBloque].restantesMobile = data.bloques[position.indexBloque].restantesMobile + cant;
                 }
                 turno.emitidoPor = ''; // Blanqueamos el emitido por (VER SI LO DEJAMOS O LO BLANQUEAMOS CUANDO EL PACIENTE LO ELIMINA)
@@ -1489,4 +1489,13 @@ export async function verificarSolapamiento(data) {
         }
     }
     return response;
+}
+
+// Verifica si un turno fue dado por la appMobile o el totem
+export function esVirtual(turnoEmitido) {
+    if (turnoEmitido === 'appMobile' || turnoEmitido === 'totem') {
+        return true;
+    } else {
+        return false;
+    }
 }


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/AM-34

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Al cancelar un turno programado se verifica si fue emitido por la App-mobile, en caso de serlo se aumenta la cantidad de restantesMobile. Luego se setea a vacio _emitidoPor_



### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No
