### PR TITLE
MPI: Link temporales

### DIFF
--- a/core/mpi/controller/paciente.ts
+++ b/core/mpi/controller/paciente.ts
@@ -500,6 +500,36 @@ export async function actualizarFinanciador(req, next) {
     }
 }
 
+export async function linkPacientes(req, dataLink, pacienteBase, pacienteLinkeado, op) {
+    if (op === 'link') {
+        if (pacienteBase.identificadores) {
+            pacienteBase.identificadores.push(dataLink);
+        } else {
+            pacienteBase.identificadores = [dataLink]; // Primer elemento del array
+        }
+        pacienteLinkeado.activo = false;
+    }
+    if (op === 'unlink') {
+        if (pacienteBase.identificadores) {
+            pacienteBase.identificadores = pacienteBase.identificadores.filter(x => x.valor !== dataLink.valor);
+        }
+        pacienteLinkeado.activo = true;
+    }
+
+    const connElastic = new ElasticSync();
+    Auth.audit(pacienteLinkeado, req);
+    await pacienteLinkeado.save();
+    await connElastic.sync(pacienteLinkeado);
+
+    Auth.audit(pacienteBase, req);
+    const pacienteSaved = await pacienteBase.save();
+    await connElastic.sync(pacienteBase);
+
+    andesLog(req, logKeys.mpiUpdate.key, pacienteBase.paciente._id, req.body.op, pacienteBase.paciente, pacienteLinkeado.paciente);
+    return pacienteSaved;
+
+}
+
 export async function checkCarpeta(req, data) {
     if (req.body && req.body.carpetaEfectores) {
 
@@ -622,7 +652,7 @@ export async function checkRepetido(nuevoPaciente, incluirTemporales = true): Pr
     // Extraemos los validados de los resultados
     let similaresValidados = candidatos.filter(elem => elem.paciente.estado === 'validado');
     // Si el nuevo paciente está validado, filtramos los candidatos temporales
-    if (nuevoPaciente.estado === 'validado' || !incluirTemporales) {
+    if (!incluirTemporales) {
         candidatos = similaresValidados;
     }
 
@@ -1005,6 +1035,20 @@ EventCore.on('mpi:patient:create', async (patientCreated) => {
             body: patientCreated
         };
         await actualizarGeoReferencia(patientCreated, patientRequest);
+        // linkea los pacientes validados con los temporales con un alto porcentaje de match
+        const resultado = await checkRepetido(patientCreated, true);
+        if (resultado.macheoAlto && resultado.resultadoMatching.length > 0) {
+            // Verifica los resultados y linkea los pacientes
+            resultado.resultadoMatching.forEach(async pacienteLink => {
+                if (pacienteLink.paciente) {
+                    const dataLink = {
+                        entidad: 'ANDES',
+                        valor: pacienteLink.paciente.id
+                    };
+                    await linkPacientes(patientRequest, dataLink, patientCreated, pacienteLink.paciente, 'link');
+                }
+            });
+        }
     }
 
 });

--- a/core/mpi/controller/paciente.ts
+++ b/core/mpi/controller/paciente.ts
@@ -518,16 +518,20 @@ export async function linkPacientes(req, dataLink, pacienteBase, pacienteLinkead
 
     const connElastic = new ElasticSync();
     Auth.audit(pacienteLinkeado, req);
-    await pacienteLinkeado.save();
-    await connElastic.sync(pacienteLinkeado);
+    try {
+        await pacienteLinkeado.save();
+        await connElastic.sync(pacienteLinkeado);
 
-    Auth.audit(pacienteBase, req);
-    const pacienteSaved = await pacienteBase.save();
-    await connElastic.sync(pacienteBase);
+        Auth.audit(pacienteBase, req);
+        const pacienteSaved = await pacienteBase.save();
+        await connElastic.sync(pacienteBase);
 
-    andesLog(req, logKeys.mpiUpdate.key, pacienteBase.paciente._id, req.body.op, pacienteBase.paciente, pacienteLinkeado.paciente);
-    return pacienteSaved;
-
+        andesLog(req, logKeys.mpiUpdate.key, pacienteBase._id, op, pacienteBase, pacienteLinkeado);
+        return pacienteSaved;
+    } catch {
+        andesLog(req, logKeys.mpiUpdate.key, pacienteBase._id, op, pacienteBase, 'Error insertando paciente');
+        return null;
+    }
 }
 
 export async function checkCarpeta(req, data) {

--- a/core/mpi/jobs/elasticFix.ts
+++ b/core/mpi/jobs/elasticFix.ts
@@ -47,7 +47,7 @@ export async function elasticFix(done) {
                 await log.log(userScheduler, logKeys.elasticFix2.key, hit, logKeys.elasticFix2.operacion, pac._id);
                 await fixAgendasPrestaciones(idElastic, idPaciente, hit);
             }
-            connElastic.sync(pac);
+            await connElastic.sync(pac);
         }
 
         /*

--- a/utils/elasticSync.ts
+++ b/utils/elasticSync.ts
@@ -81,7 +81,7 @@ export class ElasticSync {
     }
 
     public async create(id, data) {
-        const created = await this.connElastic.create({
+        const created = await this.connElastic.index({
             index: this.INDEX,
             type: this.TYPE,
             id,


### PR DESCRIPTION

### Requerimiento

- Linkea paciente validado con los temporales con un match igual o superior a la cota estipulada, que indica que son pacientes iguales
- Cambia el método update de Elastic, implementado con un delete y create, por la opción correspondiente (index). 

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Refactor del la ruta de identificadores de pacientes
2.  Resuelve los incidentes de conflictos de versiones actuales de Elastic (version conflict, document already exists)
3. La función de linkeo de pacientes temporales se realiza en el evento de creación de un paciente


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
