### PR TITLE
fix(auth): payload token parse to string

### DIFF
--- a/auth/auth.controller.ts
+++ b/auth/auth.controller.ts
@@ -23,7 +23,7 @@ export function createPayload(user, authOrg, prof) {
     const apellido = (prof && prof.apellido) || user.apellido;
     return {
         usuario: {
-            id: user._id,
+            id: String(user._id),
             nombreCompleto: nombre + ' ' + apellido,
             nombre,
             apellido,
@@ -31,11 +31,11 @@ export function createPayload(user, authOrg, prof) {
             documento: user.usuario
         },
         organizacion: {
-            _id: authOrg._id,
-            id: authOrg._id,
+            _id: String(authOrg._id),
+            id: String(authOrg._id),
             nombre: authOrg.nombre
         },
-        profesional: prof && prof._id,
+        profesional: String(prof && prof._id),
         permisos: [...user.permisosGlobales, ...authOrg.permisos]
     };
 }


### PR DESCRIPTION
### Requerimiento
Como algunos datos del token no están más en el "token", se obtienen de la base de datos. Los IDs se estaban guardando como ObjectId.

### Funcionalidad desarrollada 

1. Castea a String datos del token.


### UserStories llegó a completarse
- [ ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [ ] Si
- [ ] No
