### PR TITLE
Reportes diarios: Arreglo en los timezones de la consulta

### DIFF
--- a/modules/turnos/controller/reportesDiariosController.ts
+++ b/modules/turnos/controller/reportesDiariosController.ts
@@ -42,7 +42,13 @@ export async function getResumenDiarioMensual(params: any) {
             $project: {
                 _id: 0,
                 fecha: '$ejecucion.fecha',
-                dia: { $dayOfMonth: '$ejecucion.fecha' },
+                dia: {
+                    $dayOfMonth:
+                    {
+                        date: '$ejecucion.fecha',
+                        timezone: 'America/Argentina/Buenos_Aires'
+                    }
+                },
                 turnoEstado: '$estado.tipo',
                 pacienteSexo: '$paciente.sexo',
                 pacienteEdad: {
@@ -165,7 +171,7 @@ export async function getResumenDiarioMensual(params: any) {
             $project: {
                 _id: 0,
                 fechaISO:  '$fecha',
-                fecha: { $dateToString: { format: '%d-%m-%G', date: '$fecha' } },
+                fecha: { $dateToString: { format: '%d-%m-%G', date: '$fecha', timezone: 'America/Argentina/Buenos_Aires' } },
                 tag: '$_id.tag',
                 sexo: '$_id.sexo',
                 edad: '$_id.edad',
@@ -182,7 +188,6 @@ export async function getResumenDiarioMensual(params: any) {
     ];
 
     const data = await prestacionModel.aggregate(pipeline);
-    // console.log("DATA", data);
     // formateamos la data por los tres turnos disponibles o por el total
     const tags = dividirTurno ? ['mañana', 'tarde', 'noche'] : ['total'];
     const formatedData = [];


### PR DESCRIPTION
<!--
2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
Se reporto que habían días que mostraban mal el reporte, y este se debió a que existe un desface en la zona horaria que hace la consulta en la base de datos.

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se agrego el time zone _"America/Argentina/Buenos_Aires"_ en la consulta

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
