### PR TITLE
RUP: agrega a schema elementoRUP atributo bool requiereDiagnosticoPrincipal

### DIFF
--- a/modules/rup/schemas/elementoRUP.ts
+++ b/modules/rup/schemas/elementoRUP.ts
@@ -33,6 +33,13 @@ export let schema = new mongoose.Schema({
         default: false
     },
 
+    // Indica si este elementoRUP requiere indicar diagnostico principal
+    requiereDiagnosticoPrincipal: {
+        type: Boolean,
+        required: false,
+        default: true
+    },
+
     // true si no muestra el label de motivo de consulta.
     motivoConsultaOpcional: Boolean,
 

--- a/modules/rup/schemas/elementoRUP.ts
+++ b/modules/rup/schemas/elementoRUP.ts
@@ -40,9 +40,6 @@ export let schema = new mongoose.Schema({
         default: true
     },
 
-    // true si no muestra el label de motivo de consulta.
-    motivoConsultaOpcional: Boolean,
-
     // Parámetros generales a la hora de iniciar la prestación
     /**
      * titulo: label parametrizado


### PR DESCRIPTION
 
### Requerimiento 
https://proyectos.andes.gob.ar/browse/RUP-99
### Funcionalidad desarrollada  
1. Agrega a schema elementoRUP atributo bool requiereDiagnosticoPrincipal
2. Remueve `motivoConsultaOpcional` en desuso

### UserStories llegó a completarse 
- [x] Si https://proyectos.andes.gob.ar/browse/RUP-99
- [ ] No

### Requiere actualizaciones en la base de datos 
- [ ] Si
- [x] No
 

### ATENCIÓN
Se aplica un cambio en el requerimiento de diagnostico principal. Anteriormente las prestaciones no nominalizadas y las prestaciones de internación no requerían un diagnostico principal.

A partir de ahora se configura dinámicamente desde elementos-rup, individualizado por tipo prestación.

Se sugiere agregar el campo `requiereDiagnosticoPrincipal` en false en las prestaciones de internación y las no nominalizadas, para mantener la funcionalidad. 

### Script tentativo
```
db.getCollection('internacionEstados').aggregate([
    { $unwind: '$estados' },
    { $unwind: '$estados.acciones' },
    { $match: { 'estados.acciones.tipo': 'nuevo-registro'  } },
    { $group: {  _id: '$estados.acciones.parametros.concepto.conceptId' } },
    { $group: {  _id: null, conceptos: { $addToSet : "$_id" } } }, 
]) 

db.getCollection('conceptoTurneable').aggregate([
    { $match: {noNominalizada: true} },
    { $group: {  _id: null, conceptos: { $addToSet : "$conceptId" } } }, 
]);

db.getCollection('elementosRUP').updateMany({
    'conceptos.conceptId': { $in: [  RESULTADO DE LA UNION DE LAS DOS QUERIES ] }
    
    },  { $set: { requiereDiagnosticoPrincipal: false } } )
```
En nuestra base de datos, los conceptos de prestaciones no nominalizadas estaban en varios elemntos rup, por lo que primero se corrigio esa información. 
