### PR TITLE
GDU: se borra permiso de lectura de perfiles

### DIFF
--- a/auth/permisos.ts
+++ b/auth/permisos.ts
@@ -229,7 +229,6 @@ export default [
             {
                 key: 'perfiles', title: 'Perfiles de usuarios', avoidAll: true,
                 child: [
-                    { key: 'read', title: 'Ver perfiles de usuarios', type: 'boolean' },
                     { key: 'write', title: 'Crear/modificar perfiles de usuarios', type: 'boolean' }
                 ]
             }

--- a/modules/gestor-usuarios/perfil.routes.ts
+++ b/modules/gestor-usuarios/perfil.routes.ts
@@ -10,8 +10,8 @@ class PerfilesResource extends ResourceBase {
     resourceName = 'perfiles';
     middlewares = [Auth.authenticate()];
     routesAuthorization = {
-        get: Auth.authorize('usuarios:perfiles:read'),
-        search: Auth.authorize('usuarios:perfiles:read'),
+        get: Auth.authorize('usuarios:read'),
+        search: Auth.authorize('usuarios:read'),
         post: Auth.authorize('usuarios:perfiles:write'),
         patch: Auth.authorize('usuarios:perfiles:write'),
         delete: Auth.authorize('usuarios:perfiles:write'),


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/GDU-1

### Funcionalidad desarrollada 
1. Se borra el permiso usuarios:perfiles:read
2. Se verifica el permiso usuarios:read para las rutas get/search de perfiles

### UserStories llegó a completarse
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No

