### PR TITLE
RUP: setea x defecto profesional a solicitud rup sin profesional

### DIFF
--- a/modules/rup/routes/prestacion.ts
+++ b/modules/rup/routes/prestacion.ts
@@ -524,6 +524,8 @@ router.patch('/prestaciones/:id', (req, res, next) => {
                         }
 
                         updateRegistroHistorialSolicitud(data.solicitud, 'asignacionProfesional');
+                    } else if (req.body.estado.tipo === 'ejecucion' && !data.solicitud.profesional.id) { // si se ejecuta una solicitud que viene de rup sin profesional, se lo setea por defecto
+                        data.solicitud.profesional = Auth.getProfesional(req);
                     }
                 }
                 if (req.body.registros) {


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
<!-- URL de la User Story, referencia al issue (#1111) o breve descripcion del requerimiento -->
https://proyectos.andes.gob.ar/browse/RUP-130
### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. En el patch de solicitudes, al momento de ejecutar una solicitud sin profesional, se lo setea por defecto con el usuario de sesión (el que ejecutó la prestación).


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si https://proyectos.andes.gob.ar/browse/RUP-130
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
