### PR TITLE
fix(internacion): internaciones sin camas informe pdf

### DIFF
--- a/modules/descargas/informe-rup/informe-rup.ts
+++ b/modules/descargas/informe-rup/informe-rup.ts
@@ -46,9 +46,11 @@ export class InformeRUP extends InformePDF {
                 prestacion.paciente.id,
                 prestacion.ejecucion.fecha
             );
-            const sectores = cama.sectores || [];
-            cama.sectorName = [...sectores].reverse().map(s => s.nombre).join(', ');
-            return cama;
+            if (cama) {
+                const sectores = cama.sectores || [];
+                cama.sectorName = [...sectores].reverse().map(s => s.nombre).join(', ');
+                return cama;
+            }
         }
         return null;
     }


### PR DESCRIPTION
### Requerimiento
Hay prestaciones de internacion que no se cargan desde el mapa de camas, por ende no tienen cama asociada. 

### Funcionalidad desarrollada 
1. Control de camas


### UserStories llegó a completarse
- [ ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [ ] Si
- [ ] No

