### PR TITLE
Reporte diarios: Timezones en division de turnos & Sobreturnos y fuera de agenda en Planilla C1

### DIFF
--- a/modules/turnos/controller/reportesDiariosController.ts
+++ b/modules/turnos/controller/reportesDiariosController.ts
@@ -70,8 +70,8 @@ export async function getResumenDiarioMensual(params: any) {
                             {
                                 case: {
                                     $and: [
-                                        { $gte: [{ $hour: '$ejecucion.fecha', timezone: 'America/Argentina/Buenos_Aires' }, 7] },
-                                        { $lt: [{ $hour: '$ejecucion.fecha', timezone: 'America/Argentina/Buenos_Aires' }, 13] }
+                                        { $gte: [{ $hour: { date: '$ejecucion.fecha', timezone: 'America/Argentina/Buenos_Aires' } }, 7] },
+                                        { $lt: [{ $hour: { date: '$ejecucion.fecha', timezone: 'America/Argentina/Buenos_Aires' } }, 13] }
                                     ]
                                 },
                                 then: 'mañana'
@@ -79,8 +79,8 @@ export async function getResumenDiarioMensual(params: any) {
                             {
                                 case: {
                                     $and: [
-                                        { $gte: [{ $hour: '$ejecucion.fecha', timezone: 'America/Argentina/Buenos_Aires' }, 13] },
-                                        { $lt: [{ $hour: '$ejecucion.fecha', timezone: 'America/Argentina/Buenos_Aires' }, 20] }
+                                        { $gte: [{ $hour: { date: '$ejecucion.fecha', timezone: 'America/Argentina/Buenos_Aires' } }, 13] },
+                                        { $lt: [{ $hour: { date: '$ejecucion.fecha', timezone: 'America/Argentina/Buenos_Aires' } }, 20] }
                                     ]
                                 },
                                 then: 'tarde'


### PR DESCRIPTION
### Requerimiento
En el Reporte Diario Mensual, al dividir el turno por horarios, estos se desfasan.
En la Planilla C1, no cuenta los sobreturnos y fuera de agenda .

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1.  Corrección en los timezones al momento de hacer la consulta en la BD
2.  En planilla C1, consultar la tabla prestaciones y luego cruzar los datos con la tabla agenda para obtener la Obra Social.
3.  Filtrar por profesional en la planilla C1

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No
