### PR TITLE
refactor(rup): remove refsetids from snomed schema

### DIFF
--- a/core/term/controller/snomed.snowstorm.ts
+++ b/core/term/controller/snomed.snowstorm.ts
@@ -48,8 +48,7 @@ export async function getConcept(sctid, format = 'full') {
                 conceptId: concept.conceptId,
                 term: concept.pt.term,
                 fsn: concept.fsn.term,
-                semanticTag: getSemanticTagFromFsn(concept.fsn.term),
-                refsetIds: []
+                semanticTag: getSemanticTagFromFsn(concept.fsn.term)
             };
         }
     }
@@ -109,8 +108,7 @@ export async function getChildren(sctid, { all = false, completed = true, leaf =
                         conceptId: cpt.conceptId,
                         term: cpt.pt.term,
                         fsn: cpt.fsn.term,
-                        semanticTag: getSemanticTagFromFsn(cpt.fsn.term),
-                        refsetIds: []
+                        semanticTag: getSemanticTagFromFsn(cpt.fsn.term)
                     });
                 } else {
                     result.push(cpt.conceptId);
@@ -140,7 +138,6 @@ export async function getConcepts(conceptsIds: string[]) {
                 term: concept.pt.term,
                 fsn: concept.fsn.term,
                 semanticTag: getSemanticTagFromFsn(concept.fsn.term),
-                refsetIds: [],
                 relationships: concept.relationships
             };
         });
@@ -168,8 +165,7 @@ export async function getConceptByExpression(expression, term = null, form = 'st
                     conceptId: concept.conceptId,
                     term: concept.pt.term,
                     fsn: concept.fsn.term,
-                    semanticTag: getSemanticTagFromFsn(concept.fsn.term),
-                    refsetIds: [],
+                    semanticTag: getSemanticTagFromFsn(concept.fsn.term)
                 };
             });
             return ps;
@@ -347,8 +343,7 @@ export async function searchTerms(text, { semanticTags, languageCode }, conceptI
     return searchResult3.hits.hits.map(a => {
         return {
             ...hash[a._source.conceptId],
-            term: a._source.term,
-            refsetIds: []
+            term: a._source.term
         };
     }).sort((a: any, b: any) => {
         if (a.term.length < b.term.length) { return -1; }

--- a/modules/rup/controllers/codificacionController.ts
+++ b/modules/rup/controllers/codificacionController.ts
@@ -66,8 +66,7 @@ export function codificarPrestacion(unaPrestacion: any) {
                                         conceptId: registro.concepto.conceptId,
                                         term: registro.concepto.term,
                                         fsn: registro.concepto.fsn,
-                                        semanticTag: registro.concepto.semanticTag,
-                                        refsetIds: registro.concepto.refsetIds
+                                        semanticTag: registro.concepto.semanticTag
                                     },
                                     cie10: codigoCie10
                                 },
@@ -81,8 +80,7 @@ export function codificarPrestacion(unaPrestacion: any) {
                                         conceptId: registro.concepto.conceptId,
                                         term: registro.concepto.term,
                                         fsn: registro.concepto.fsn,
-                                        semanticTag: registro.concepto.semanticTag,
-                                        refsetIds: registro.concepto.refsetIds
+                                        semanticTag: registro.concepto.semanticTag
                                     },
                                     cie10: codigoCie10
                                 },

--- a/modules/rup/internacion/camas.controller.test.ts
+++ b/modules/rup/internacion/camas.controller.test.ts
@@ -43,7 +43,6 @@ function seedCama() {
         },
         ambito: 'internacion',
         unidadOrganizativa: {
-            refsetIds: [],
             fsn: 'servicio de adicciones (medio ambiente)',
             term: 'servicio de adicciones',
             conceptId: '4561000013106',
@@ -159,8 +158,7 @@ describe('Internacion - camas', () => {
                 fsn: 'cama saturada (objeto físico)',
                 term: 'cama saturada',
                 conceptId: '1234567890',
-                semanticTag: 'objeto físico',
-                refsetIds: []
+                semanticTag: 'objeto físico'
             }
         }, REQMock);
 
@@ -190,8 +188,7 @@ describe('Internacion - camas', () => {
                 fsn: 'cama saturada (objeto físico)',
                 term: 'cama saturada',
                 conceptId: '1234567890',
-                semanticTag: 'objeto físico',
-                refsetIds: []
+                semanticTag: 'objeto físico'
             }
         }, REQMock);
         expect(resultNull).toBeNull();
@@ -297,8 +294,7 @@ describe('Internacion - camas', () => {
                 fsn: 'cama saturada (objeto físico)',
                 term: 'cama saturada',
                 conceptId: '1234567890',
-                semanticTag: 'objeto físico',
-                refsetIds: []
+                semanticTag: 'objeto físico'
             }
         }, REQMock);
 
@@ -343,7 +339,6 @@ describe('Internacion - camas', () => {
                 nombre: 'HOSPITAL NEUQUEN'
             },
             unidadOrganizativa: {
-                refsetIds: [],
                 fsn: 'servicio de adicciones (medio ambiente)',
                 term: 'servicio de adicciones',
                 conceptId: '4561000013103',
@@ -365,7 +360,6 @@ function estadoOcupada() {
         fecha: moment().toDate(),
         estado: 'ocupada',
         unidadOrganizativa: {
-            refsetIds: [],
             fsn: 'servicio de adicciones (medio ambiente)',
             term: 'servicio de adicciones',
             conceptId: '4561000013106',
@@ -375,7 +369,6 @@ function estadoOcupada() {
         },
         especialidades: [
             {
-                refsetIds: [],
                 _id: mongoose.Types.ObjectId('5c95036cc5861a722ddd563d'),
                 fsn: 'medicina general (calificador)',
                 term: 'medicina general',
@@ -385,7 +378,6 @@ function estadoOcupada() {
         ],
         esCensable: true,
         genero: {
-            refsetIds: [],
             fsn: 'género femenino (hallazgo)',
             term: 'género femenino',
             conceptId: '703118005',
@@ -478,14 +470,12 @@ function prestacion() {
         _id: mongoose.Types.ObjectId('5d3af64ec8d7a7158e12c242'),
         solicitud: {
             tipoPrestacion: {
-                refsetIds: [],
                 fsn: 'admisión hospitalaria (procedimiento)',
                 semanticTag: 'procedimiento',
                 conceptId: '32485007',
                 term: 'internación'
             },
             tipoPrestacionOrigen: {
-                refsetIds: []
             },
             organizacion: {
                 id: mongoose.Types.ObjectId('57f67a7ad86d9f64130a138d'),
@@ -523,9 +513,6 @@ function prestacion() {
                     concepto: {
                         fsn: 'documento de solicitud de admisión (elemento de registro)',
                         semanticTag: 'elemento de registro',
-                        refsetIds: [
-                            '900000000000497000'
-                        ],
                         conceptId: '721915006',
                         term: 'documento de solicitud de admisión'
                     },
@@ -608,9 +595,6 @@ function prestacion() {
                     concepto: {
                         fsn: 'alta del paciente (procedimiento)',
                         semanticTag: 'procedimiento',
-                        refsetIds: [
-                            '900000000000497000'
-                        ],
                         conceptId: '58000006',
                         term: 'alta del paciente'
                     },

--- a/modules/rup/internacion/censo.controller.test.ts
+++ b/modules/rup/internacion/censo.controller.test.ts
@@ -50,7 +50,6 @@ function seedCama() {
         },
         ambito: 'internacion',
         unidadOrganizativa: {
-            refsetIds: [],
             fsn: 'servicio de adicciones (medio ambiente)',
             term: 'servicio de adicciones',
             conceptId: '4561000013106',
@@ -182,7 +181,6 @@ test('Censo diario - Paciente desde 0hs tiene pase A', async () => {
         term: 'departamento de neuropatología',
         conceptId: '309957000',
         semanticTag: 'medio ambiente',
-        refsetIds: []
     };
     await CamasEstadosController.store({ organizacion: '57f67a7ad86d9f64130a138d', ambito: 'internacion', capa: 'estadistica', cama: String(cama._id) }, nuevoOcupado, REQMock);
 
@@ -332,7 +330,6 @@ test('Censo diario - Paciente ingresa y tiene pase A', async () => {
         term: 'departamento de neuropatología',
         conceptId: '309957000',
         semanticTag: 'medio ambiente',
-        refsetIds: []
     };
     await CamasEstadosController.store({ organizacion: '57f67a7ad86d9f64130a138d', ambito: 'internacion', capa: 'estadistica', cama: String(cama._id) }, nuevoEstado, REQMock);
 
@@ -371,7 +368,6 @@ test('Censo diario - Paciente ingresa y tiene paseA y luego paseDe y se queda', 
         term: 'departamento de neuropatología',
         conceptId: '309957000',
         semanticTag: 'medio ambiente',
-        refsetIds: []
     };
     await CamasEstadosController.store({ organizacion: '57f67a7ad86d9f64130a138d', ambito: 'internacion', capa: 'estadistica', cama: String(cama._id) }, nuevoEstado, REQMock);
 
@@ -416,7 +412,6 @@ test('Censo diario - Paciente ingresa y tiene paseA y luego paseDe y tiene alta'
         term: 'departamento de neuropatología',
         conceptId: '309957000',
         semanticTag: 'medio ambiente',
-        refsetIds: []
     };
     await CamasEstadosController.store({ organizacion: '57f67a7ad86d9f64130a138d', ambito: 'internacion', capa: 'estadistica', cama: String(cama._id) }, nuevoEstado, REQMock);
 
@@ -463,7 +458,6 @@ test('Censo diario - Paciente ingresa y tiene paseA y luego paseDe y tiene defun
         term: 'departamento de neuropatología',
         conceptId: '309957000',
         semanticTag: 'medio ambiente',
-        refsetIds: []
     };
     await CamasEstadosController.store({ organizacion: '57f67a7ad86d9f64130a138d', ambito: 'internacion', capa: 'estadistica', cama: String(cama._id) }, nuevoEstado, REQMock);
 
@@ -504,7 +498,6 @@ test('Censo diario - Paciente tiene paseDe y se queda', async () => {
         term: 'departamento de neuropatología',
         conceptId: '309957000',
         semanticTag: 'medio ambiente',
-        refsetIds: []
     };
     await CamasEstadosController.store({ organizacion: '57f67a7ad86d9f64130a138d', ambito: 'internacion', capa: 'estadistica', cama: String(cama._id) }, nuevoOcupado, REQMock);
 
@@ -546,7 +539,6 @@ test('Censo diario - Paciente tiene paseDe y tiene alta', async () => {
         term: 'departamento de neuropatología',
         conceptId: '309957000',
         semanticTag: 'medio ambiente',
-        refsetIds: []
     };
     await CamasEstadosController.store({ organizacion: '57f67a7ad86d9f64130a138d', ambito: 'internacion', capa: 'estadistica', cama: String(cama._id) }, nuevoOcupado, REQMock);
 
@@ -590,7 +582,6 @@ test('Censo diario - Paciente tiene paseDe y tiene defuncion', async () => {
         term: 'departamento de neuropatología',
         conceptId: '309957000',
         semanticTag: 'medio ambiente',
-        refsetIds: []
     };
     await CamasEstadosController.store({ organizacion: '57f67a7ad86d9f64130a138d', ambito: 'internacion', capa: 'estadistica', cama: String(cama._id) }, nuevoOcupado, REQMock);
 
@@ -629,7 +620,6 @@ test('Censo diario - Paciente tiene paseDe y tiene paseA', async () => {
         term: 'departamento de neuropatología',
         conceptId: '309957000',
         semanticTag: 'medio ambiente',
-        refsetIds: []
     };
     await CamasEstadosController.store({ organizacion: '57f67a7ad86d9f64130a138d', ambito: 'internacion', capa: 'estadistica', cama: String(cama._id) }, nuevoOcupado, REQMock);
 
@@ -646,7 +636,6 @@ test('Censo diario - Paciente tiene paseDe y tiene paseA', async () => {
         term: 'departamento de neuropatología',
         conceptId: '309957000',
         semanticTag: 'medio ambiente',
-        refsetIds: []
     };
     await CamasEstadosController.store({ organizacion: '57f67a7ad86d9f64130a138d', ambito: 'internacion', capa: 'estadistica', cama: String(cama._id) }, nuevoEstadoPase, REQMock);
 
@@ -671,7 +660,7 @@ function estadoOcupada() {
         fecha: moment().subtract(1, 'day').toDate(),
         estado: 'ocupada',
         unidadOrganizativa: {
-            refsetIds: [],
+
             fsn: 'servicio de adicciones (medio ambiente)',
             term: 'servicio de adicciones',
             conceptId: '4561000013106',
@@ -681,7 +670,7 @@ function estadoOcupada() {
         },
         especialidades: [
             {
-                refsetIds: [],
+
                 _id: mongoose.Types.ObjectId('5c95036cc5861a722ddd563d'),
                 fsn: 'medicina general (calificador)',
                 term: 'medicina general',
@@ -691,7 +680,7 @@ function estadoOcupada() {
         ],
         esCensable: true,
         genero: {
-            refsetIds: [],
+
             fsn: 'género femenino (hallazgo)',
             term: 'género femenino',
             conceptId: '703118005',
@@ -784,14 +773,14 @@ function prestacion() {
         _id: mongoose.Types.ObjectId('5d3af64ec8d7a7158e12c242'),
         solicitud: {
             tipoPrestacion: {
-                refsetIds: [],
+
                 fsn: 'admisión hospitalaria (procedimiento)',
                 semanticTag: 'procedimiento',
                 conceptId: '32485007',
                 term: 'internación'
             },
             tipoPrestacionOrigen: {
-                refsetIds: []
+
             },
             organizacion: {
                 id: mongoose.Types.ObjectId('57f67a7ad86d9f64130a138d'),
@@ -829,9 +818,6 @@ function prestacion() {
                     concepto: {
                         fsn: 'documento de solicitud de admisión (elemento de registro)',
                         semanticTag: 'elemento de registro',
-                        refsetIds: [
-                            '900000000000497000'
-                        ],
                         conceptId: '721915006',
                         term: 'documento de solicitud de admisión'
                     },
@@ -914,9 +900,6 @@ function prestacion() {
                     concepto: {
                         fsn: 'alta del paciente (procedimiento)',
                         semanticTag: 'procedimiento',
-                        refsetIds: [
-                            '900000000000497000'
-                        ],
                         conceptId: '58000006',
                         term: 'alta del paciente'
                     },

--- a/modules/rup/routes/frecuentesProfesional.ts
+++ b/modules/rup/routes/frecuentesProfesional.ts
@@ -52,7 +52,6 @@ router.get('/frecuentesProfesional', async (req, res, next) => {
                     conceptId: '$frecuentes.concepto.conceptId',
                     term: '$frecuentes.concepto.term',
                     fsn: '$frecuentes.concepto.fsn',
-                    refsetIds: '$frecuentes.concepto.refsetIds',
                     semanticTag: '$frecuentes.concepto.semanticTag'
                 },
                 frecuencia: { $sum: '$frecuentes.frecuencia' },

--- a/modules/rup/schemas/prestacion.ts
+++ b/modules/rup/schemas/prestacion.ts
@@ -54,7 +54,6 @@ export let schema = new mongoose.Schema({
             term: String,
             fsn: String,
             semanticTag: SemanticTag,
-            refsetIds: [String],
             noNominalizada: Boolean
         },
         tipoPrestacionOrigen: {
@@ -62,8 +61,7 @@ export let schema = new mongoose.Schema({
             conceptId: String,
             term: String,
             fsn: String,
-            semanticTag: SemanticTag,
-            refsetIds: [String]
+            semanticTag: SemanticTag
         },
 
         // ID del turno relacionado con esta prestación

--- a/modules/rup/schemas/snomed-concept.ts
+++ b/modules/rup/schemas/snomed-concept.ts
@@ -5,13 +5,11 @@ export interface ISnomedConcept {
     term: String;
     fsn: String;
     semanticTag: String;
-    refsetIds: String[];
 }
 
 export let SnomedConcept = {
     conceptId: String,
     term: String,
     fsn: String,
-    semanticTag: SemanticTag,
-    refsetIds: [String]
+    semanticTag: SemanticTag
 };

--- a/modules/top/schemas/reglas.ts
+++ b/modules/top/schemas/reglas.ts
@@ -29,8 +29,7 @@ let reglasSchema = new mongoose.Schema({
             conceptId: String,
             term: String,
             fsn: String,
-            semanticTag: SemanticTag,
-            refsetIds: [String]
+            semanticTag: SemanticTag
         }
     }
 });

--- a/modules/turnos/controller/agenda.ts
+++ b/modules/turnos/controller/agenda.ts
@@ -255,8 +255,7 @@ export function codificarTurno(req, data, tid) {
                                         conceptId: registro.concepto.conceptId,
                                         term: registro.concepto.term,
                                         fsn: registro.concepto.fsn,
-                                        semanticTag: registro.concepto.semanticTag,
-                                        refsetIds: registro.concepto.refsetIds
+                                        semanticTag: registro.concepto.semanticTag
                                     },
                                     cie10: codigoCie10
                                 },
@@ -270,8 +269,7 @@ export function codificarTurno(req, data, tid) {
                                         conceptId: registro.concepto.conceptId,
                                         term: registro.concepto.term,
                                         fsn: registro.concepto.fsn,
-                                        semanticTag: registro.concepto.semanticTag,
-                                        refsetIds: registro.concepto.refsetIds
+                                        semanticTag: registro.concepto.semanticTag
                                     },
                                     cie10: codigoCie10
                                 },


### PR DESCRIPTION
### Funcionalidad desarrollada 
1. Borra el schema de snomed  el campo refsetids que esta en desuso. Así no se genera un array vacío en la DB.

### UserStories llegó a completarse
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No
