### PR TITLE
refactor(snomed): snowstorm soporta multiple semanticTags

### DIFF
--- a/config.private.ts.example
+++ b/config.private.ts.example
@@ -109,7 +109,6 @@ export const puco = {
 
 export const snomed = {
     snowstormHost: getEnv('SNOWSTORM_HOST', 'http://localhost:8080'),
-    snowstormElastic: getEnv('SNOWSTORM_ELASTIC', 'http://localhost:9201'),
     snowstormBranch: getEnv('SNOWSTORM_BRANCH', 'MAIN/SNOMEDCT-ES')
 };
 


### PR DESCRIPTION
### Requerimiento
La última versión de Snowstorm agregó un filtro por varios semanticTags, así que ya no es necesario consumir directamente desde elasticsearch.

### UserStories llegó a completarse
- [ ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [ ] Si
- [ ] No
