### PR TITLE
RUP: al validar prestación auditar agenda para no nominalizadas

### DIFF
--- a/auth/auth.class.ts
+++ b/auth/auth.class.ts
@@ -213,6 +213,20 @@ export class Auth {
         };
     }
 
+    static getUserFromResource(resource: any) {
+        const auditData = resource.updatedBy || resource.createdBy;
+        const user = {
+            usuario: auditData,
+            organizacion: auditData.organizacion,
+            ip: '0.0.0.0',
+            connection: {
+                localAddress: '0.0.0.0'
+            }
+        };
+        delete user.usuario.organizacion;
+        return { user };
+    }
+
 
     /**
      * Genera los registros de auditoría en el documento indicado

--- a/modules/turnos/controller/agenda.ts
+++ b/modules/turnos/controller/agenda.ts
@@ -948,6 +948,7 @@ async function actualizarAux(agenda: any) {
     });
 }
 
+
 /**
  * Llegado el día de ejecucion de la agenda, los turnos restantesProgramados pasan a restantesDelDia
  *
@@ -1079,6 +1080,19 @@ EventCore.on('mpi:patient:update', async (pacienteModified) => {
     //         }
     //     });
     // }
+});
+
+// Audita una agenda si es no nominalizada, si se realizo una validación de la prestación
+EventCore.on('rup:prestacion:validate', async (prestacion) => {
+    if (prestacion.solicitud.tipoPrestacion.noNominalizada) {
+        const idTurno = prestacion.solicitud.turno;
+        let agenda: any = await agendaModel.findOne({ 'bloques.turnos._id': { $eq: idTurno, $exists: true } });
+        if (agenda) {
+            agenda.estado = 'auditada';
+            Auth.audit(agenda, (userScheduler as any));
+            await saveAgenda(agenda);
+        }
+    }
 });
 
 /**

--- a/modules/turnos/controller/agenda.ts
+++ b/modules/turnos/controller/agenda.ts
@@ -1061,35 +1061,16 @@ export function saveAgenda(nuevaAgenda) {
 }
 
 
-// Actualiza el paciente dentro del turno, si se realizo un update del paciente (Eventos entre módulos)
-EventCore.on('mpi:patient:update', async (pacienteModified) => {
-    // let req = {
-    //     query: {
-    //         estado: 'asignado',
-    //         pacienteId: pacienteModified.id,
-    //         horaInicio: moment(new Date()).startOf('day').toDate() as any
-    //     }
-    // };
-    // let turnos: any = await turnosController.getTurno(req);
-    // if (turnos.length > 0) {
-    //     turnos.forEach(element => {
-    //         try {
-    //             agendaController.updatePaciente(pacienteModified, element);
-    //         } catch (error) {
-    //             return error;
-    //         }
-    //     });
-    // }
-});
-
 // Audita una agenda si es no nominalizada, si se realizo una validación de la prestación
 EventCore.on('rup:prestacion:validate', async (prestacion) => {
-    if (prestacion.solicitud.tipoPrestacion.noNominalizada) {
-        const idTurno = prestacion.solicitud.turno;
-        let agenda: any = await agendaModel.findOne({ 'bloques.turnos._id': { $eq: idTurno, $exists: true } });
+    const noNominalizada = prestacion.solicitud.tipoPrestacion.noNominalizada;
+    const idTurno = prestacion.solicitud.turno;
+    if (noNominalizada && idTurno) {
+        const agenda: any = await agendaModel.findOne({ 'bloques.turnos._id': idTurno });
         if (agenda) {
             agenda.estado = 'auditada';
-            Auth.audit(agenda, (userScheduler as any));
+            const user = Auth.getUserFromResource(prestacion);
+            Auth.audit(agenda, user as any);
             await saveAgenda(agenda);
         }
     }

--- a/modules/version/routes/routes.ts
+++ b/modules/version/routes/routes.ts
@@ -1,10 +1,11 @@
 import * as express from 'express';
-
+import * as config from '../../../config.private';
 let router = express.Router();
 
 router.get('/', async (req, res) => {
     res.json({
-        version: require('../../../package.json').version
+        version: require('../../../package.json').version,
+        snomed: config.snomed.snowstormBranch
     });
 });
 


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/RUP-136

### Funcionalidad desarrollada 
1. Al captar el evento  'rup:prestacion:validate', desde el controlador de agenda se audita la agenda correspondiente a la prestación si es no nominalizada.

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [X] No
