### PR TITLE
RUP: Marcar asistencia del turno en background

### DIFF
--- a/modules/turnos/controller/agenda.ts
+++ b/modules/turnos/controller/agenda.ts
@@ -1078,6 +1078,19 @@ EventCore.on('rup:prestacion:validate', async (prestacion) => {
     }
 });
 
+// Audita una agenda si es no nominalizada, si se realizo una validación de la prestación
+EventCore.on('rup:prestacion:validate', async (prestacion) => {
+    if (prestacion.solicitud.tipoPrestacion.noNominalizada) {
+        const idTurno = prestacion.solicitud.turno;
+        let agenda: any = await agendaModel.findOne({ 'bloques.turnos._id': { $eq: idTurno, $exists: true } });
+        if (agenda) {
+            agenda.estado = 'auditada';
+            Auth.audit(agenda, (userScheduler as any));
+            await saveAgenda(agenda);
+        }
+    }
+});
+
 /**
  * Actualiza el paciente embebido en el turno.
  *


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/RUP-135

### Funcionalidad desarrollada 
1. Se guarda la asistencia del paciente a un turno mediante EventCore 'rup:prestacion:validate'

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [X] No

