### PR TITLE
Organizaciones - Códigos para mapeo de ServSalud

### DIFF
--- a/core/tm/interfaces/IContacto.ts
+++ b/core/tm/interfaces/IContacto.ts
@@ -1,0 +1,7 @@
+export interface IContacto {
+    tipo: any;
+    valor: string;
+    ranking: number;
+    activo: boolean;
+    ultimaActualizacion: Date;
+}

--- a/core/tm/interfaces/IDireccion.ts
+++ b/core/tm/interfaces/IDireccion.ts
@@ -1,0 +1,11 @@
+import { IUbicacion } from './IUbicacion';
+
+export interface IDireccion {
+    valor: String;
+    codigoPostal: String;
+    ubicacion: IUbicacion;
+    ranking: Number;
+    geoReferencia: [Number, Number];
+    ultimaActualizacion: Date;
+    activo: Boolean;
+}

--- a/core/tm/interfaces/IOrganizacion.ts
+++ b/core/tm/interfaces/IOrganizacion.ts
@@ -1,0 +1,47 @@
+import { ITipoEstablecimiento } from './ITipoEstablecimiento';
+import { IDireccion } from './IDireccion';
+import { IContacto } from './IContacto';
+import { ISnomedConcept } from '../../../modules/rup/schemas/snomed-concept';
+import { ISectores } from './ISectores';
+import { ITipoPrestacion } from '../schemas/tipoPrestacion';
+
+export interface IOrganizacion {
+    id: string;
+    codigo: {
+        sisa: String,
+        cuie: String,
+        remediar: String,
+        servSalud: String,
+    };
+    nombre: String;
+    tipoEstablecimiento: ITipoEstablecimiento;
+    // direccion
+    direccion: IDireccion;
+    // contacto
+    contacto: [IContacto];
+    edificio: [{
+        id: String,
+        descripcion: String,
+        contacto: IContacto,
+        direccion: IDireccion,
+    }];
+    nivelComplejidad: Number;
+    activo: Boolean;
+    fechaAlta: Date;
+    fechaBaja: Date;
+    servicios: [ISnomedConcept];
+    mapaSectores: ISectores[];
+    unidadesOrganizativas: [ISnomedConcept];
+    /**
+     * "prestaciones" traidas de sisa. Se muestran en la app mobile
+     * @type {[{ idSisa: number, nombre: string }]}
+     * @memberof IOrganizacion
+     */
+    ofertaPrestacional?: [{ _id: string, prestacion: ITipoPrestacion, detalle: string }];
+    /**
+     * Indica si debe mostrarse en los mapas. Por defecto se muestra en los hospitales, centro de salud, punto sanitario
+     * @type {boolean}
+     * @memberof IOrganizacion
+     */
+    showMapa?: boolean;
+}

--- a/core/tm/interfaces/ISectores.ts
+++ b/core/tm/interfaces/ISectores.ts
@@ -1,0 +1,8 @@
+import { ISnomedConcept } from '../../../modules/rup/schemas/snomed-concept';
+
+export interface ISectores {
+    tipoSector: ISnomedConcept;
+    unidadConcept?: ISnomedConcept;
+    nombre: String;
+    hijos?: ISectores[];
+}

--- a/core/tm/interfaces/ITipoEstablecimiento.ts
+++ b/core/tm/interfaces/ITipoEstablecimiento.ts
@@ -1,0 +1,6 @@
+export interface ITipoEstablecimiento {
+    nombre: String;
+    descripcion: String;
+    clasificacion: String;
+    idTipoEfector: Number;
+}

--- a/core/tm/interfaces/IUbicacion.ts
+++ b/core/tm/interfaces/IUbicacion.ts
@@ -1,0 +1,18 @@
+export interface IUbicacion {
+    barrio: {
+        id: String,
+        nombre: String
+    };
+    localidad: {
+        id: String,
+        nombre: String
+    };
+    provincia: {
+        id: String,
+        nombre: String
+    };
+    pais: {
+        id: String,
+        nombre: String
+    };
+}

--- a/core/tm/routes/tipoPrestacion.ts
+++ b/core/tm/routes/tipoPrestacion.ts
@@ -2,6 +2,7 @@ import * as utils from '../../../utils/utils';
 import * as express from 'express';
 import { tipoPrestacion } from '../schemas/tipoPrestacion';
 import * as mongoose from 'mongoose';
+import { Auth } from '../../../auth/auth.class';
 
 const router = express.Router();
 const ObjectId = mongoose.Types.ObjectId;
@@ -51,6 +52,15 @@ router.get('/tiposPrestaciones/:id*?', (req, res, next) => {
         }
         res.json(data);
     });
+});
+
+router.put('/tiposPrestaciones/:id', Auth.authenticate(), async (req, res, next) => {
+    try {
+        const result = await tipoPrestacion.findByIdAndUpdate(req.params.id, req.body);
+        return res.json(result);
+    } catch (err) {
+        return next(err);
+    }
 });
 
 export = router;

--- a/core/tm/schemas/organizacion.ts
+++ b/core/tm/schemas/organizacion.ts
@@ -1,4 +1,4 @@
-import { Schema, model, SchemaTypes } from 'mongoose';
+import { Schema, model, SchemaTypes, Document } from 'mongoose';
 import * as edificioSchema from './edificio';
 import * as direccionSchema from './direccion';
 import * as contactoSchema from './contacto';
@@ -6,6 +6,7 @@ import * as tipoEstablecimientoSchema from './tipoEstablecimiento';
 import { SnomedConcept } from '../../../modules/rup/schemas/snomed-concept';
 import { AuditPlugin } from '@andes/mongoose-plugin-audit';
 import { tipoPrestacionSchema } from './tipoPrestacion';
+import { IOrganizacion } from '../interfaces/IOrganizacion';
 
 export let MapaSectoresSchema = new Schema({
     tipoSector: SnomedConcept,
@@ -24,7 +25,8 @@ let CodigoSchema = new Schema({
     },
     cuie: String,
     remediar: String,
-    sips: String
+    sips: String,
+    servSalud: String,
 });
 
 const _schema = new Schema({
@@ -62,4 +64,4 @@ const _schema = new Schema({
 _schema.plugin(AuditPlugin);
 
 export const OrganizacionSchema = _schema;
-export const Organizacion = model('organizacion', _schema, 'organizacion');
+export const Organizacion = model<IOrganizacion & Document>('organizacion', _schema, 'organizacion');

--- a/core/tm/schemas/tipoPrestacion.ts
+++ b/core/tm/schemas/tipoPrestacion.ts
@@ -6,6 +6,7 @@ export interface ITipoPrestacion extends Document {
     term: String;
     fsn: String;
     semanticTag: 'procedimiento' | 'solicitud' | 'hallazgo' | 'trastorno' | 'antecedenteFamiliar' | 'régimen/tratamiento';
+    codigoServSalud?: String;
 }
 
 
@@ -22,6 +23,9 @@ export let tipoPrestacionSchema = new Schema({
         type: Boolean,
         required: false,
         default: true
+    },
+    codigoServSalud: {
+        type: String,
     }
 });
 


### PR DESCRIPTION
### Requerimiento
ServSalud necesita generar automáticamente un reporte basado en reportes diario mensual, es por eso que se agregó los códigos para realizar el correcto mapeo.

### Funcionalidad desarrollada 
1. Interfaces de Organización, Tipo de Prestación & Ubicación
2. Actualización de los Schemas para los modelos correspondiente a las interfaces anteriores
3. Métodos PATCH que modifica solamente el código de ServSalud para Organización y Tipo de Prestación


### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
