### PR TITLE
feat(mapa-camas): registros filtros por unidad organizativa

### DIFF
--- a/modules/rup/internacion/estados.schema.ts
+++ b/modules/rup/internacion/estados.schema.ts
@@ -29,7 +29,8 @@ const EstadoSchema = new Schema({
             label: String,
             tipo: String,
             parametros: {
-                concepto: { type: SnomedConcept, require: false }
+                concepto: { type: SnomedConcept, require: false },
+                unidadOrganizativa: { type: [String], require: false }
             }
         }]
     }],


### PR DESCRIPTION
### Requerimiento
La prestación de atención domiciliaria COVID, solo debe aparecer en la unidad organizativa de COVID. 

### Funcionalidad desarrollada 
1. Se crea un filtro de registro por unidad organizativa. 


### UserStories llegó a completarse 
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos 
- [ ] Si
- [x] No

APP:  https://github.com/andes/app/pull/1814