### PR TITLE
fix(pecas): corrige todas las apariciones de comillas en el domicilio del paciente

### DIFF
--- a/modules/estadistica/pecas/controller/agenda.ts
+++ b/modules/estadistica/pecas/controller/agenda.ts
@@ -96,7 +96,7 @@ async function insertCompleto(turno: any, idEfectorSips) {
     let pacienteApellido = turno.Apellido ? turno.Apellido.replace('\'', '\'\'') : null;
     let pacienteNombres = turno.Nombres ? turno.Nombres.replace('\'', '\'\'') : null;
     let pacienteObraSocial = turno.ObraSocial ? turno.ObraSocial.replace('\'', '\'\'') : null;
-    let calle = turno.Calle ? turno.Calle.replace('\'', '\'\'') : null;
+    let calle = turno.Calle ? turno.Calle.replace(/'/g, '\'\'') : null;
     let turnosDelDia = turno.turnosDelDia ? turno.turnosDelDia : null;
     let turnosLlaves = turno.turnosLlaves ? turno.turnosLlaves : null;
     let pacienteTelefono = turno.Telefono ? turno.Telefono : null;


### PR DESCRIPTION
### Requerimiento
Corregir bug que se produce cuando el domicilio tiene mas de una comilla (Ej: PARCELA 'A' 11 )

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No
