### PR TITLE
Permisos: nuevos permisos para modulo visualizacion de informacion

### DIFF
--- a/auth/permisos.ts
+++ b/auth/permisos.ts
@@ -293,13 +293,7 @@ export default [
             { key: 'paciente', title: 'Setear paciente', type: 'boolean' },
         ]
     },
-    {
-        key: 'reportes',
-        title: 'Módulo Reportes',
-        comment: 'Estadística',
-        child: [
-        ]
-    },
+
     {
         key: 'descargas',
         title: 'Descarga de Documentos',
@@ -400,21 +394,38 @@ export default [
         ]
     },
     {
-        key: 'dashboard',
-        title: 'Panel de datos estadísticos en gráficos y tablas',
+        key: 'visualizacionInformacion',
+        title: 'Gestion de la visualización de información',
         child: [
             {
-                key: 'citas', title: 'Dashboard Citas', child: [
-                    { key: 'ver', title: 'Ver Dashboard Citas', type: 'boolean' },
-                    { key: 'verProfesionales', title: 'Ver todos los profesionales', type: 'boolean' },
-                    { key: 'tipoPrestacion', title: 'Tipo de prestación', type: 'prestacion' },
+                key: 'dashboard',
+                title: 'Panel de datos estadísticos en gráficos y tablas',
+                child: [
+                    {
+                        key: 'citas', title: 'Dashboard Citas', child: [
+                            { key: 'ver', title: 'Ver Dashboard Citas', type: 'boolean' },
+                            { key: 'verProfesionales', title: 'Ver todos los profesionales', type: 'boolean' },
+                            { key: 'tipoPrestacion', title: 'Tipo de prestación', type: 'prestacion' },
+                        ]
+                    },
+                    {
+                        key: 'top', title: 'Dashboard TOP', child: [
+                            { key: 'ver', title: 'Ver Dashboard Top', type: 'boolean' }
+                        ]
+                    }
                 ]
             },
             {
-                key: 'top', title: 'Dashboard TOP', child: [
-                    { key: 'ver', title: 'Ver Dashboard Top', type: 'boolean' }
-                ]
-            }
+                key: 'reportes',
+                title: 'Módulo Reportes',
+                type: 'boolean'
+
+            },
+            {
+                key: 'biQueries',
+                title: 'Bi-Queries',
+                type: 'boolean'
+            },
         ]
     },
     {

--- a/modules/turnos/routes/agenda.ts
+++ b/modules/turnos/routes/agenda.ts
@@ -712,7 +712,7 @@ router.patch('/agenda/:id*?', (req, res, next) => {
 
 router.post('/dashboard', async (req, res, next) => {
     const permisos: any = {};
-    let tipoPrestacion = Auth.getPermissions(req, 'dashboard:citas:tipoPrestacion:?');
+    let tipoPrestacion = Auth.getPermissions(req, 'visualizacionInformacion:dashboard:citas:tipoPrestacion:?');
     if (tipoPrestacion.length > 0 && tipoPrestacion[0] !== '*') {
         permisos.tipoPrestacion = tipoPrestacion;
     }
@@ -768,7 +768,7 @@ router.post('/dashboard/descargarCsv', async (req, res, next) => {
 
 router.post('/dashboard/localidades', async (req, res, next) => {
     const permisos: any = {};
-    let tipoPrestacion = Auth.getPermissions(req, 'dashboard:citas:tipoPrestacion:?');
+    let tipoPrestacion = Auth.getPermissions(req, 'visualizacionInformacion:dashboard:citas:tipoPrestacion:?');
     if (tipoPrestacion.length > 0 && tipoPrestacion[0] !== '*') {
         permisos.tipoPrestacion = tipoPrestacion;
     }

--- a/scripts/visualizacion-informacion.ts
+++ b/scripts/visualizacion-informacion.ts
@@ -1,0 +1,67 @@
+import { AuthUsers } from '../auth/schemas/authUsers';
+import { Modulos } from '../core/tm/schemas/modulos.schema';
+
+async function run(done) {
+    // Elimino los modulos
+    await Modulos.remove({ nombre: 'DASHBOARD' });
+    await Modulos.remove({ nombre: 'Reportes' });
+
+    // Inserto nuevo modulo
+    await Modulos.insertMany({
+        permisos: [
+            'visualizacionInformacion:?'
+        ],
+        activo: true,
+        nombre: 'VISUALIZACIÓN DE INFORMACIÓN',
+        descripcion: 'Permite gestionar la visualizacion de salida de informacion',
+        subtitulo: 'Gestión de la informacion',
+        color: '#07049f',
+        icono: 'mdi-file-chart',
+        linkAcceso: '/visualizacion-informacion',
+        orden: 12,
+        __v: 0
+    });
+
+    // Actualizo los permisos
+    let organizaciones: any = AuthUsers.aggregate([
+        {
+            $project: {
+                organizaciones: 1,
+                id: '$_id'
+            }
+        },
+        {
+            $unwind: '$organizaciones'
+        }
+    ]);
+    for await (const user of organizaciones) {
+        const match = user.organizaciones.permisos.find(value => /^reportes/.test(value));
+        const match2 = user.organizaciones.permisos.find(value => /^dashboard/.test(value));
+        if (match) {
+            await AuthUsers.update(
+                { _id: user._id, 'organizaciones._id': user.organizaciones._id, 'organizaciones.permisos': match },
+                {
+                    $set: {
+                        'organizaciones.$[].permisos.$[element]': 'visualizacionInformacion:' + match
+                    }
+                },
+                { arrayFilters: [{ element: match }] }
+            );
+        }
+        if (match2) {
+            await AuthUsers.update(
+                { _id: user._id, 'organizaciones._id': user.organizaciones._id, 'organizaciones.permisos': match2 },
+                {
+                    $set: {
+                        'organizaciones.$[].permisos.$[element]': 'visualizacionInformacion:' + match2
+                    }
+                },
+                { arrayFilters: [{ element: match2 }] }
+            );
+        }
+
+    }
+    done();
+}
+
+export = run;


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/BI-53

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se agregan como hijos del permiso visualizacionInformacion reportes  y dashboards con sus descendientes
2. Se agrega el permiso biQueries como hijo del permiso visualizacionInformacion.
3. Se crea Script para actualizar los permisos existentes dada la nueva organización.


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [x] Si 
- [ ] No

1. Ejecutar Script 

El script elimina los modulos _Reportes_ y Dashboard e inserta el nuevo _Visualización de información_. Luego realiza una búsqueda por toda la colección AuthUsers y verifica si en cada organización que tenga el usuario posee permisos para reportes o dashboard, en caso de que así sea modifica el permiso agregándole la palabra "visualizacionInformacion:" por delante para que funcione de manera correcta con la modificación actual. 

```bash
node scripts visualizacion-informacion
```