### PR TITLE
fix(historial TOP): guarda observaciones al citar paciente

### DIFF
--- a/modules/rup/controllers/prestacion.ts
+++ b/modules/rup/controllers/prestacion.ts
@@ -68,7 +68,7 @@ export function updateRegistroHistorialSolicitud(solicitud, datos) {
     registroHistorial.accion = descripcionesAccion[_accion] === undefined ?  'indefinida' : _accion;
     registroHistorial.descripcion = descripcionesAccion[registroHistorial.accion];
 
-    let observaciones = datos.op === 'estadoPush' ? datos.estado.observaciones : datos.observaciones;
+    let observaciones = datos.op === 'estadoPush' || datos.op === 'citar' ? datos.estado.observaciones : datos.observaciones;
     if (observaciones) {
         registroHistorial.observaciones = observaciones;
     }


### PR DESCRIPTION
### Requerimiento
Cuando el profesional cita un paciente y agrega observaciones, ese dato no se está almacenando en el historial

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se agrega control en updateRegistroHistorialSolicitud

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si 
- [x] No
