### PR TITLE
fix(snowstorm): too heavy request

### DIFF
--- a/core/term/controller/snomed.snowstorm.ts
+++ b/core/term/controller/snomed.snowstorm.ts
@@ -166,7 +166,7 @@ export async function getConceptByExpression(expression, term = null, form = 'st
             return ps;
         }
     }
-    return null;
+    return [];
 }
 
 async function searchByDescription({ text, semanticTags, languageCode }) {


### PR DESCRIPTION
### Requerimiento
Hay request que snowstorm devuelve un mensaje de error porque es una request muy HEAVY. Por ejemplo cuando se busca por una sola letra. (No todos los plex-select tiene un minimo de caracteres).

Por eso en ves de devolver null, la API devuelve array vacío así no genera un fallo en la app. 

### UserStories llegó a completarse
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No
