### PR TITLE
fix(rup): conversión explícita a objectId

### DIFF
--- a/modules/cda/routes/cda.ts
+++ b/modules/cda/routes/cda.ts
@@ -282,7 +282,7 @@ router.get('/:id', async (req: any, res, next) => {
     //     return next(403);
     // }
 
-    const _base64 = req.params.id;
+    const _base64 = Types.ObjectId(req.params.id);
     const CDAFiles = makeFs();
     const contexto = await CDAFiles.findOne({ _id: _base64 });
     CDAFiles.readFile({ _id: _base64 }, (err, buffer) => {

--- a/modules/descargas/informe-rup/elementos-rup/adjuntar-documento.component.ts
+++ b/modules/descargas/informe-rup/elementos-rup/adjuntar-documento.component.ts
@@ -1,6 +1,7 @@
 import { HTMLComponent } from '../../model/html-component.class';
 import * as mime from 'mime-types';
 import * as rupStore from '../../../rup/controllers/rupStore';
+import { Types } from 'mongoose';
 
 
 export class AdjuntarDocumentoComponent extends HTMLComponent {
@@ -42,9 +43,12 @@ export class AdjuntarDocumentoComponent extends HTMLComponent {
             .filter(doc => mime.lookup(doc.ext).indexOf('image') > -1)
             .map(documento => {
                 return new Promise(async (resolve, reject) => {
-                    const archivo = await rupStore.readFile(documento.id);
-                    const base64 = await rupStore.streamToBase64(archivo.stream);
-                    return resolve({ img: base64, term: documento?.descripcion?.term });
+                    if (documento.id) {
+                        const archivo = await rupStore.readFile({ _id: Types.ObjectId(documento.id) });
+                        const base64 = await rupStore.streamToBase64(archivo.stream);
+                        return resolve({ img: base64, term: documento?.descripcion?.term });
+                    }
+                    return;
                 });
             });
     }

--- a/modules/registro-novedades/images/controller/imageStore.ts
+++ b/modules/registro-novedades/images/controller/imageStore.ts
@@ -1,5 +1,5 @@
 import { makeFs } from '../schemas/imageStore';
-import * as mongoose from 'mongoose';
+import { Types } from 'mongoose';
 import * as base64_stream from 'base64-stream';
 import * as stream from 'stream';
 
@@ -11,7 +11,7 @@ export async function storeFile(base64, metadata) {
         const mime = match[1];
         const data = match[2];
         let writePromise = new Promise((resolve) => {
-            const uniqueId = String(new mongoose.Types.ObjectId());
+            const uniqueId = new Types.ObjectId();
             const input = new stream.PassThrough();
             const decoder64 = base64_stream.decode();
             const ImageFiles = makeFs();
@@ -38,8 +38,9 @@ export async function storeFile(base64, metadata) {
 export async function readFile(id) {
     try {
         const ImageFiles = makeFs();
-        const contexto = await ImageFiles.findOne({ _id: id });
-        const imageStream = await ImageFiles.readFile({ _id: id });
+        const idFile = new Types.ObjectId(id);
+        const contexto = await ImageFiles.findOne({ _id: idFile });
+        const imageStream = await ImageFiles.readFile({ _id: idFile });
         return {
             file: contexto,
             stream: imageStream

--- a/modules/rup/controllers/rupStore.ts
+++ b/modules/rup/controllers/rupStore.ts
@@ -1,5 +1,5 @@
 import { makeFs } from '../schemas/rupStore';
-import * as mongoose from 'mongoose';
+import { Types } from 'mongoose';
 import * as base64_stream from 'base64-stream';
 import * as stream from 'stream';
 
@@ -11,7 +11,7 @@ export function storeFile(base64, metadata) {
     const data = match[2];
 
     return new Promise((resolve, reject) => {
-        const uniqueId = String(new mongoose.Types.ObjectId());
+        const uniqueId = new Types.ObjectId();
         const input = new stream.PassThrough();
         const decoder64 = base64_stream.decode();
         const RupFiles = makeFs();
@@ -35,8 +35,9 @@ export function readFile(id): Promise<any> {
     return new Promise(async (resolve, reject) => {
         try {
             const RupFiles = makeFs();
-            const contexto = await RupFiles.findOne({ _id: id });
-            const stream2 = RupFiles.readFile({ _id: id });
+            const idFile = Types.ObjectId(id);
+            const contexto = await RupFiles.findOne({ _id: idFile });
+            const stream2 = RupFiles.readFile({ _id: idFile });
             resolve({
                 file: contexto,
                 stream: stream2
@@ -61,8 +62,9 @@ export function readAsBase64(id) {
     return new Promise(async (resolve, reject) => {
         try {
             const RupFiles = makeFs();
-            const contexto = await RupFiles.findOne({ _id: id });
-            const stream2 = RupFiles.readFile({ _id: id });
+            const idFile = Types.ObjectId(id);
+            const contexto = await RupFiles.findOne({ _id: idFile });
+            const stream2 = RupFiles.readFile({ _id: idFile });
             resolve({
                 file: contexto,
                 stream: stream2


### PR DESCRIPTION

### Requerimiento
Error al abrir imágenes o pdf adjuntos

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se agrega conversión explicita a ObjectId en RupStore e ImageStore
2. 
3. 


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
