### PR TITLE
INTERNACION - Arregla search estados que pisaba createdBy y createdAt del estado

### DIFF
--- a/modules/rup/internacion/cama-estados.controller.ts
+++ b/modules/rup/internacion/cama-estados.controller.ts
@@ -153,10 +153,22 @@ export async function snapshotEstados({ fecha, organizacion, ambito, capa }, fil
         {
             $lookup: {
                 from: 'internacionCamas',
-                localField: 'idCama',
-                foreignField: '_id',
+                let: {
+                    id: '$idCama',
+                },
+                pipeline: [
+                    {
+                        $match: {
+                            $expr: {
+                                $and: [
+                                    { $eq: ['$_id', '$$id'] },
+                                ]
+                            }
+                        }
+                    },
+                    { $project: { createdAt: 0, createdBy: 0 }}
+                ],
                 as: 'cama'
-
             }
         },
         {

--- a/modules/rup/internacion/sala-comun/sala-comun.controller.ts
+++ b/modules/rup/internacion/sala-comun/sala-comun.controller.ts
@@ -235,7 +235,7 @@ export async function listarSalaComun(opciones: ListarOptions): Promise<SalaComu
                 idInternacion: '$snapshot.idInternacion',
                 unidadOrganizativas: { $ifNull: ['$snapshot.unidadOrganizativas', '$unidadOrganizativas'] },
                 ambito: '$snapshot.ambito',
-                fecha: '$snapshot.desde',
+                fecha: { $ifNull: ['$snapshot.desde', '$fecha'] },
                 extras: '$snapshot.extras',
                 createdAt: '$snapshot.createdAt',
                 createdBy: '$snapshot.createdBy',


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
<!-- URL de la User Story, referencia al issue (#1111) o breve descripcion del requerimiento -->
La query searchEstados pisaba los atributos createdAt y createdBy del estado con el de la cama
### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Cambia el lookup que busca la cama y agrega un project para que no traiga dichos atributos.
2. 
3. 


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
