### PR TITLE
fix(citas): log suspender sobreturno

### DIFF
--- a/modules/turnos/routes/agenda.ts
+++ b/modules/turnos/routes/agenda.ts
@@ -560,7 +560,7 @@ router.patch('/agenda/:id*?', (req, res, next) => {
                     case 'liberarTurno':
                         turno = agendaCtrl.getTurno(req, data, turnos[y]);
                         // LoggerPaciente.logTurno(req, 'turnos:liberar', turno.paciente, turno, bloqueId, agendaId);
-                        LoggerPaciente.logTurno(req, 'turnos:liberar', turno.paciente, turno, agendaCtrl.getBloque(data, turno)._id, data);
+                        LoggerPaciente.logTurno(req, 'turnos:liberar', turno.paciente, turno, agendaCtrl.getBloque(data, turno)?._id, data);
                         await prestacionCtrl.liberarRefTurno(turno, req);
                         let liberado = await agendaCtrl.liberarTurno(req, data, turno);
                         if (!liberado) {
@@ -571,7 +571,7 @@ router.patch('/agenda/:id*?', (req, res, next) => {
                     case 'suspenderTurno':
                         turno = agendaCtrl.getTurno(req, data, turnos[y]);
                         if (agendaCtrl.getBloque(data, turno)) {
-                            LoggerPaciente.logTurno(req, 'turnos:suspender', (turno.paciente ? turno.paciente : null), turno, agendaCtrl.getBloque(data, turno)._id, data._id);
+                            LoggerPaciente.logTurno(req, 'turnos:suspender', (turno.paciente ? turno.paciente : null), turno, agendaCtrl.getBloque(data, turno)?._id, data._id);
                         } else {
                             // Caso sobreturno
                             LoggerPaciente.logTurno(req, 'turnos:suspender', (turno.paciente ? turno.paciente : null), turno, null, data._id);

--- a/modules/turnos/routes/agenda.ts
+++ b/modules/turnos/routes/agenda.ts
@@ -574,7 +574,7 @@ router.patch('/agenda/:id*?', (req, res, next) => {
                             LoggerPaciente.logTurno(req, 'turnos:suspender', (turno.paciente ? turno.paciente : null), turno, agendaCtrl.getBloque(data, turno)._id, data._id);
                         } else {
                             // Caso sobreturno
-                            LoggerPaciente.logTurno(req, 'turnos:suspender', (turno.paciente ? turno.paciente : null), turno, -1, data._id);
+                            LoggerPaciente.logTurno(req, 'turnos:suspender', (turno.paciente ? turno.paciente : null), turno, null, data._id);
                         }
                         agendaCtrl.suspenderTurno(req, data, turno);
                         event = { object: 'turno', accion: 'suspender', data: turno };


### PR DESCRIPTION
### Requerimiento

https://proyectos.andes.gob.ar/browse/MPI-248

```
ValidationError: logPaciente validation failed: dataTurno.idBloque: Cast to ObjectID failed for value "-1" at path "dataTurno.idBloque"
    at new ValidationError (/var/www/andes/api/source/node_modules/mongoose/lib/error/validation.js:30:11)
    at model.Document.invalidate (/var/www/andes/api/source/node_modules/mongoose/lib/document.js:2080:32)
    at model.$set (/var/www/andes/api/source/node_modules/mongoose/lib/document.js:1029:10)
    at model._handleIndex (/var/www/andes/api/source/node_modules/mongoose/lib/document.js:806:14)
    at model.$set (/var/www/andes/api/source/node_modules/mongoose/lib/document.js:756:22)
    at model._handleIndex (/var/www/andes/api/source/node_modules/mongoose/lib/document.js:786:12)
    at model.$set (/var/www/andes/api/source/node_modules/mongoose/lib/document.js:756:22)
    at model.Document (/var/www/andes/api/source/node_modules/mongoose/lib/document.js:119:12)
    at model.Model (/var/www/andes/api/source/node_modules/mongoose/lib/model.js:95:12)
    at new model (/var/www/andes/api/source/node_modules/mongoose/lib/model.js:4593:13)
    at Function.logTurno (/var/www/andes/api/source/utils/loggerPaciente.ts:6:32)
    at /var/www/andes/api/source/modules/turnos/routes/agenda.ts:577:44
    at Generator.next (<anonymous>)
    at /var/www/andes/api/source/modules/turnos/routes/agenda.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/var/www/andes/api/source/modules/turnos/routes/agenda.js:4:12)
```


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
