### PR TITLE
Turnos y prestaciones: se agrega el campo ambito

### DIFF
--- a/modules/estadistica/controller/procesarAgendas.ts
+++ b/modules/estadistica/controller/procesarAgendas.ts
@@ -177,6 +177,7 @@ export async function procesar(parametros: any) {
                 turno: '$turno',
                 idPrestacion: '$prestacion0._id',
                 estadoFacturacion: '$turno.estadoFacturacion',
+                ambito: '$prestacion0.solicitud.ambitoOrigen'
             }
         },
         {

--- a/modules/estadistica/controller/procesarFueraDeAgenda.ts
+++ b/modules/estadistica/controller/procesarFueraDeAgenda.ts
@@ -89,7 +89,8 @@ export async function procesar(parametros: any) {
                 idBloque: null,
                 turno: null,
                 idPrestacion: prestacion.idPrestacion,
-                estadoFacturacion: prestacion.estadoFacturacion
+                estadoFacturacion: prestacion.estadoFacturacion,
+                ambito: prestacion.prestacion.solicitud.ambitoOrigen
             };
 
             if (prestacion.paciente && prestacion.paciente.obraSocial === os || os === 'todos') {


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/BI-59

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Agrego al aggregate el campo ámbito tanto para los turnos como para las prestaciones fuera de agendas.


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No

