### PR TITLE
fix(turnos): corrige lógica en bloques de solo gestión

### DIFF
--- a/modules/turnos/routes/turno.ts
+++ b/modules/turnos/routes/turno.ts
@@ -203,7 +203,7 @@ router.patch('/turno/:idTurno/bloque/:idBloque/agenda/:idAgenda/', async (req, r
             esHoy = true;
         }
 
-        const contieneBloqueSoloGestion = agendaRes.bloques.some((bloque: any) => bloque.reservadoGestion > 0 && bloque.accesoDirectoDelDia === 0 || bloque.accesoDirectoProgramado === 0 || bloque.reservadoProfesional === 0);
+        const contieneBloqueSoloGestion = agendaRes.bloques.some((bloque: any) => bloque.reservadoGestion > 0 && bloque.accesoDirectoDelDia === 0 && bloque.accesoDirectoProgramado === 0 && bloque.reservadoProfesional === 0);
         // Contadores de "delDia" y "programado" varían según si es el día de hoy o no
         countBloques = {
             delDia: esHoy && !contieneBloqueSoloGestion ? (
@@ -215,7 +215,6 @@ router.patch('/turno/:idTurno/bloque/:idBloque/agenda/:idAgenda/', async (req, r
             profesional: esHoy ? 0 : (agendaRes as any).bloques[posBloque].restantesProfesional,
             mobile: esHoy ? 0 : (agendaRes as any).bloques[posBloque].restantesMobile,
         };
-
         posTurno = (agendaRes as any).bloques[posBloque].turnos.findIndex(item => item._id.toString() === req.body.idTurno.toString());
 
         const turnoSeleccionado = (agendaRes as any).bloques[posBloque].turnos[posTurno];


### PR DESCRIPTION
### Requerimiento
Por error en la lógica de un nuevo método que se agregó para permitir dar turnos de gestión hasta el mismo día de la agenda, no se están pudiendo dar turnos del día en algunos casos específicos. 

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se corrigen operadores lógicos


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
