### PR TITLE
feat(rup): agrega cache redis para frecuentes

### DIFF
--- a/connections.ts
+++ b/connections.ts
@@ -2,6 +2,7 @@ import * as mongoose from 'mongoose';
 import * as configPrivate from './config.private';
 import * as debug from 'debug';
 import { Connections as loggerConnections } from '@andes/log';
+import { AndesCache } from '@andes/core';
 
 function schemaDefaults(schema) {
     schema.set('toJSON', {
@@ -70,4 +71,12 @@ export class Connections {
         connection.on('reconnected', () => connectionLog('reconnected'));
         connection.on('disconnected', () => connectionLog('disconnected'));
     }
+}
+
+export let AppCache: AndesCache;
+
+if (configPrivate.RedisWebSockets.active) {
+    AppCache = new AndesCache({ adapter: 'redis', port: configPrivate.RedisWebSockets.port, host: configPrivate.RedisWebSockets.host });
+} else {
+    AppCache = new AndesCache({ adapter: 'memory' });
 }

--- a/modules/rup/controllers/frecuentesProfesional.ts
+++ b/modules/rup/controllers/frecuentesProfesional.ts
@@ -3,17 +3,17 @@ import { ProfesionalMeta } from '../schemas/profesionalMeta';
 export async function actualizarFrecuentes(data) {
 
     const query = {
-            // profesional
+        // profesional
         ...(data.profesional) && { 'profesional.id': data.profesional.id },
-            // organizacion
+        // organizacion
         ...(data.organizacion.id) && { 'organizacion.id': data.organizacion.id },
-            // tipoPrestacion
+        // tipoPrestacion
         ...(data.tipoPrestacion.conceptId) && { 'tipoPrestacion.conceptId': data.tipoPrestacion.conceptId }
     };
 
     const resultado = await ProfesionalMeta.findOne(query);
 
-            // si no existe agregamos el nuevo frecuente
+    // si no existe agregamos el nuevo frecuente
     if (!resultado) {
         const frecuente = new ProfesionalMeta(data);
         await frecuente.save();
@@ -27,7 +27,8 @@ export async function actualizarFrecuentes(data) {
                     resultado.frecuentes.push({
                         concepto: frecuente.concepto,
                         esSolicitud: frecuente.esSolicitud,
-                        frecuencia: 1
+                        frecuencia: 1,
+                        lastUse: new Date()
                     });
                 } else {
 
@@ -36,6 +37,7 @@ export async function actualizarFrecuentes(data) {
                     } else {
                         resultado.frecuentes[indexConcepto].frecuencia = 1;
                     }
+                    resultado.frecuentes[indexConcepto].lastUse = new Date();
                 }
             });
         }

--- a/modules/rup/routes/frecuentesProfesional.ts
+++ b/modules/rup/routes/frecuentesProfesional.ts
@@ -1,51 +1,51 @@
-/**
- * Schema definido en profesionalMeta.ts
- */
-
 import * as express from 'express';
 import * as mongoose from 'mongoose';
+import { AppCache } from '../../../connections';
 import { ProfesionalMeta } from './../schemas/profesionalMeta';
-import { toArray } from '../../../utils/utils';
 
 const router = express.Router();
 
-router.get('/frecuentesProfesional/:id', async (req, res, next) => {
-    try {
-        const frecuente = await ProfesionalMeta.find({ 'profesional.id': req.params.id });
-
-        if (!frecuente) {
-            return next(404);
-        }
-
-        if (frecuente[0] && frecuente[0].frecuentes) {
-            frecuente[0].frecuentes.sort((a, b) => a.frecuencia - b.frecuencia);
-        }
-
-        return res.json(frecuente);
-    } catch (err) {
-        return next(err);
-    }
-});
 
 router.get('/frecuentesProfesional', async (req, res, next) => {
     if (!req.query.tipoPrestacion) {
         return next(404);
     }
 
-    const query = {
-        // profesional
-        ...(req.query.idProfesional) && { 'profesional.id': mongoose.Types.ObjectId(req.query.idProfesional) },
-        // organizacion
-        ...(req.query.idOrganizacion) && { 'organizacion.id': mongoose.Types.ObjectId(req.query.idOrganizacion) },
-        // tipoPrestacion
-        ...(req.query.tipoPrestacion) && { 'tipoPrestacion.conceptId': req.query.tipoPrestacion }
-    };
+    const idProfesional = req.query.idProfesional;
+    const idOrganizacion = req.query.idOrganizacion;
+    const tipoPrestacion = req.query.tipoPrestacion;
 
+    const key = `frecuentes-${(idProfesional || '')}-${(idOrganizacion || '')}-${(tipoPrestacion || '')}`;
+    const frecuentesCache = await AppCache.get(key);
+    if (frecuentesCache) {
+        return res.json(frecuentesCache);
+    }
+
+
+    const query = {};
+
+    if (idProfesional) {
+        query['profesional.id'] = mongoose.Types.ObjectId(idProfesional);
+    }
+
+    if (idOrganizacion) {
+        query['organizacion.id'] = mongoose.Types.ObjectId(idOrganizacion);
+    }
+
+    if (tipoPrestacion) {
+        query['tipoPrestacion.conceptId'] = tipoPrestacion;
+    }
 
     const pipeline = [
         { $match: query },
         { $unwind: '$frecuentes' },
-        { $project: { 'frecuentes.concepto': 1, 'frecuentes.frecuencia': 1, 'frecuentes.esSolicitud': 1, _id: 0 } },
+        {
+            $project: {
+                'frecuentes.concepto': 1,
+                'frecuentes.frecuencia': 1,
+                'frecuentes.esSolicitud': 1, _id: 0
+            }
+        },
         {
             $group: {
                 _id: {
@@ -63,75 +63,15 @@ router.get('/frecuentesProfesional', async (req, res, next) => {
     ];
 
     try {
-        const frecuente = await toArray(ProfesionalMeta.aggregate(pipeline).cursor({}).exec());
-        res.json(frecuente);
-    } catch (err) {
-        return next(err);
-    }
+        const frecuentes = await ProfesionalMeta.aggregate(pipeline);
 
-});
+        res.json(frecuentes);
 
-/**
- * No esta en uso
- * [Deprecated]
- */
-router.post('/frecuentesProfesional', async (req, res, next) => {
-
-    if (!req.body) {
-        return next(400);
-    }
-
-    const frecuente = new ProfesionalMeta(req.body);
-    try {
-        frecuente.save();
-        return res.json(frecuente);
-    } catch (err) {
-        return next(err);
-    }
-
-});
-
-/**
- * No esta en uso
- * [Deprecated]
- */
-router.put('/frecuentesProfesional/:id', async (req, res, next) => {
-    const query = {
-        // profesional
-        ...(req.params.id) && { 'profesional.id': req.params.id },
-        // organizacion
-        ...(req.body.organizacion.id) && { 'organizacion.id': req.body.organizacion.id },
-        // tipoPrestacion
-        ...(req.body.tipoPrestacion.conceptId) && { 'tipoPrestacion.conceptId': req.body.tipoPrestacion.conceptId }
-    };
-
-    try {
-        const resultado: any = await ProfesionalMeta.findOne(query);
-        if (typeof resultado === null || !resultado) {
-            const frecuente = new ProfesionalMeta(req.body);
-            await frecuente.save();
-            return res.json(resultado);
-
-        } else {
-
-            if (req.body.frecuentes) {
-                req.body.frecuentes.forEach(frecuente => {
-                    // frecuente.conceptos.forEach(concepto => {
-
-                    const indexConcepto = resultado.frecuentes.findIndex(x => x.concepto.conceptId === frecuente.concepto.conceptId);
-
-                    if (indexConcepto === -1) {
-                        resultado.frecuentes.push(frecuente);
-                    } else {
-                        resultado.frecuentes[indexConcepto].frecuencia = parseInt(resultado.frecuentes[indexConcepto].frecuencia, 0) + 1;
-                    }
-                    // });
-                });
-            }
-
-            await resultado.save();
-            return res.json(resultado);
+        if (frecuentes.length >= 20) {
+            AppCache.set(key, frecuentes, 60 * 60 * 2);
         }
+
+
     } catch (err) {
         return next(err);
     }

--- a/modules/rup/schemas/profesionalMeta.ts
+++ b/modules/rup/schemas/profesionalMeta.ts
@@ -26,6 +26,7 @@ export interface IProfesionalMeta extends mongoose.Document {
         concepto: ISnomedConcept;
         esSolicitud: Boolean;
         frecuencia: number;
+        lastUse: Date;
     }];
 }
 
@@ -46,8 +47,9 @@ export let ProfesionalMetaSchema = new mongoose.Schema({
         // tipo de prestacion desde la cual se solicita
         concepto: SnomedConcept,
         esSolicitud: Boolean,
-        frecuencia: Number
+        frecuencia: Number,
+        lastUse: Date
     }]
 });
 
-export let ProfesionalMeta: mongoose.Model<IProfesionalMeta> = mongoose.model<IProfesionalMeta>('profesionalMeta', ProfesionalMetaSchema, 'profesionalMeta');
+export const ProfesionalMeta: mongoose.Model<IProfesionalMeta> = mongoose.model<IProfesionalMeta>('profesionalMeta', ProfesionalMetaSchema, 'profesionalMeta');


### PR DESCRIPTION
### Requerimiento
En algunos casos el calculo de frecuentes se hace muy demandante, todo el tiempo y ya son larga listas de conceptos. 
Como primer medida vamos a aplicar Cache mediante de REDIS cuando la lista es más 20 conceptos, así mantenemos la actualización real time cuando arranca una prestación o profesional a registrar. 

La idea es empezar a experimentar con algo no tan crítico como los frecuentes, antes de llegar a otras secciones. 

https://github.com/andes/app/pull/2019

### UserStories llegó a completarse
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [ ] Si
- [X] No

