### PR TITLE
fix(mpi): agrega match de localidades en validación

### DIFF
--- a/core/mpi/routes/paciente.ts
+++ b/core/mpi/routes/paciente.ts
@@ -207,7 +207,7 @@ router.get('/pacientes/:id/foto/:fotoId', async (req, res, next) => {
         const idPaciente = req.params.id;
         const pacienteBuscado: any = await paciente.findById(idPaciente, '+foto');
         if (pacienteBuscado) {
-            if (!pacienteBuscado.fotoId) {
+            if (!pacienteBuscado.fotoId || !pacienteBuscado.foto || pacienteBuscado.foto == null) {
                 res.writeHead(200, {
                     'Content-Type': 'image/svg+xml'
                 });
@@ -229,7 +229,7 @@ router.get('/pacientes/:id/foto/:fotoId', async (req, res, next) => {
         }
 
     } catch (err) {
-        return next('Paciente no encontrado');
+        return next(err);
     }
 
 });

--- a/core/tm/controller/localidad.ts
+++ b/core/tm/controller/localidad.ts
@@ -22,10 +22,10 @@ export async function matchUbicacion(searchProvincia: string, searchLocalidad: s
     });
     const localidades: any = await localidad.find({ 'provincia._id': matchProvincia[1]._id });
     match = 0;
-
+    const loc = searchLocalidad.toLocaleLowerCase().replace(/_|\./g, '');
     // seleccionamos localidad con matching mas alto
     localidades.forEach(unaLoc => {
-        match = alg.levenshtein(searchLocalidad, unaLoc.nombre);
+        match = alg.levenshtein(loc, unaLoc.nombre);
         matchLocalidad = (match > matchLocalidad[0]) ? [match, unaLoc] : matchLocalidad;
     });
     return { provincia: matchProvincia[1], localidad: matchLocalidad[1] };


### PR DESCRIPTION

### Requerimiento
Agrega match de ubicación en los nuevos controladores de validación.  Actualmente utilizada en el proceso de importar pacientes recién nacidos.  



### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1.  Agrega match de localidad y provincia
2. Agrega control para la foto del paciente
3. 


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
