### PR TITLE
refactor(sms): quita servicio de sms

### DIFF
--- a/utils/roboSender/sendSms.ts
+++ b/utils/roboSender/sendSms.ts
@@ -12,6 +12,7 @@ export interface SmsOptions {
 
 export function sendSms(smsOptions: SmsOptions) {
     return new Promise((resolve, reject) => {
+        return reject('sin servicio de sms');
         log('Enviando SMS a ', smsOptions.telefono);
         const argsOperador = {
             telefono: smsOptions.telefono


### PR DESCRIPTION

### Requerimiento
Quita momentáneamente los envios de sms debido a que el servicio no se encuentra actualmente operativo

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. 
2. 
3. 


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
