### PR TITLE
fix(puco): cambia uso de sisa por federador

### DIFF
--- a/config.private.ts.example
+++ b/config.private.ts.example
@@ -106,6 +106,15 @@ export const puco = {
     }
 };
 
+// Configuración BUS INTEROPERABILIDAD
+export const busInteroperabilidad = {
+    host: getEnv('HOSTBUS', ''),
+    usuario: getEnv('BUS_USERNAME', ''),
+    clave: getEnv('BUS_PASS', ''),
+    dominio: getEnv('BUS_DOMINIO', '')
+
+};
+
 export const snomed = {
     snowstormHost: getEnv('SNOWSTORM_HOST', 'http://localhost:8080'),
     snowstormBranch: getEnv('SNOWSTORM_BRANCH', 'MAIN/SNOMEDCT-ES')

--- a/modules/obraSocial/controller/obraSocial.ts
+++ b/modules/obraSocial/controller/obraSocial.ts
@@ -6,7 +6,7 @@ import { IObraSocial, ObraSocial } from '../schemas/obraSocial';
 export async function getObraSocial(paciente) {
     if (!paciente.documento) { return []; }
 
-    let arrayOSPuco: any = await pacientePuco(paciente.documento);
+    let arrayOSPuco: any = await pacientePuco(paciente.documento, paciente.sexo);
     if (arrayOSPuco.length > 0) {
         return arrayOSPuco;
     } else {

--- a/modules/obraSocial/routes/obraSocial.ts
+++ b/modules/obraSocial/routes/obraSocial.ts
@@ -72,9 +72,11 @@ router.get('/padronSumar', Auth.authenticate(), async (req, res, next) => {
  */
 
 router.get('/puco', Auth.authenticate(), async (req, res, next) => {
-    if (req.query.dni) {
+    const dni = req.query.dni;
+    if (dni) {
         const padron = req.query.periodo ? req.query.periodo : null;
-        const respOSPuco: IPuco[] = await pucoController.getOSPuco(req.query.dni, padron);
+        const sexo = req.query.sexo || 0;
+        const respOSPuco: IPuco[] = await pucoController.getOSPuco(dni, sexo, padron);
         if (respOSPuco.length > 0) {
             const resultOS = [];
             try {


### PR DESCRIPTION
### Requerimiento
Utiliza el servicio del federador para actualizar las obras sociales

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Quita el uso del servicio de Sisa en obras sociales
2. 
3. 


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [ ] No

### Cambios en el config private


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
