### PR TITLE
feat(nomivac): registro de aplicaciones de vacunas

### DIFF
--- a/config.private.ts.example
+++ b/config.private.ts.example
@@ -80,6 +80,7 @@ export const sisa = {
     url: getEnv('SISA_URL', 'https://sisa.msal.gov.ar/sisa/services/rest/cmdb/obtener?'),
     urlEstablecimiento: getEnv('SISA_URL_ESTABLECIMIENTO', 'https://sisa.msal.gov.ar/sisa/services/rest/establecimiento/'),
     urlPrestacionesPorEfector: getEnv('SISA_URL_PRESTACIONES', 'https://sisa.msal.gov.ar/sisa/services/rest/establecimiento/prestaciones/'),
+    url_nomivac: getEnv('NOMIVAC_URL', 'https://ws200-qa.sisa.msal.gov.ar/nomivacAplicacion/v1/aplicaciones/alta/')
 };
 // Configuración servicio ANSES
 export const anses = {

--- a/core/log/schemas/logExportaInformacion.ts
+++ b/core/log/schemas/logExportaInformacion.ts
@@ -1,0 +1,18 @@
+import * as mongoose from 'mongoose';
+
+export const informacionExportadaSchema = new mongoose.Schema({
+    fecha: {
+        type: Date
+    },
+    sistema: String,
+    key: String,
+    idPaciente: mongoose.Schema.Types.ObjectId,
+    info_enviada: { type: mongoose.Schema.Types.Mixed },
+    resultado: { type: mongoose.Schema.Types.Mixed }
+});
+
+informacionExportadaSchema.index({ fecha: 1, sistema: 1, key: 1 });
+informacionExportadaSchema.index({ fecha: 1, idPaciente: 1 });
+
+export const InformacionExportada = mongoose.model('nomivacInformacionExportada', informacionExportadaSchema,
+    'nomivacInformacionExportada');

--- a/jobs/exportCovid19.ts
+++ b/jobs/exportCovid19.ts
@@ -73,12 +73,7 @@ export async function exportCovid19(done, horas) {
                 sexo: '$sexo',
                 nombre: '$nombre',
                 apellido: '$apellido',
-                direccion: {
-                    $arrayElemAt: [
-                        '$direccion.valor',
-                        0
-                    ]
-                },
+                direccion: '$direccion.valor',
                 fechaNacimiento: {
                     $dateToString: {
                         date: '$fechaNacimiento',

--- a/jobs/exportCovid19.ts
+++ b/jobs/exportCovid19.ts
@@ -1,0 +1,192 @@
+import * as moment from 'moment';
+import { Prestacion } from '../modules/rup/schemas/prestacion';
+import { InformacionExportada } from '../core/log/schemas/logExportaInformacion';
+import { handleHttpRequest } from '../utils/requestHandler';
+import { sisa } from './../config.private';
+const fs = require('fs');
+
+const user = sisa.username;
+const clave = sisa.password;
+const urlSisa = sisa.url_nomivac;
+
+export async function exportCovid19(done, horas) {
+    const start = moment().subtract(horas, 'h').toDate();
+    const end = moment().toDate();
+    const pipelineVacunaCovid19 = [
+        {
+            $match: {
+                'solicitud.fecha': {
+                    $gte: start, $lte: end
+                },
+                'estadoActual.tipo': 'validada',
+                'ejecucion.registros.concepto.conceptId': '840534001'
+
+            }
+        },
+        {
+            $project: {
+                _id: 0,
+                idPaciente: '$paciente.id',
+                dni: '$paciente.documento',
+                sexo: '$paciente.sexo',
+                nombre: '$paciente.nombre',
+                apellido: '$paciente.apellido',
+                fechaNacimiento: '$paciente.fechaNacimiento',
+                fecha: '$solicitud.fecha',
+                idEfector: '$solicitud.organizacion.id',
+                vacuna: '$ejecucion.registros.valor.vacuna'
+            }
+        },
+        {
+            $lookup: {
+                from: 'organizacion',
+                localField: 'idEfector',
+                foreignField: '_id',
+                as: 'organizacion'
+            }
+        },
+        { $unwind: '$organizacion' },
+        {
+            $lookup: {
+                from: 'paciente',
+                localField: 'idPaciente',
+                foreignField: '_id',
+                as: 'dirPaciente'
+            }
+        },
+        { $unwind: '$dirPaciente' },
+        {
+            $addFields: {
+                direccion: {
+                    $arrayElemAt: [
+                        '$dirPaciente.direccion',
+                        0
+                    ]
+                }
+            }
+        },
+        {
+            $project: {
+                tipo: 'vacuna',
+                idPaciente: '$idPaciente',
+                dni: '$dni',
+                sexo: '$sexo',
+                nombre: '$nombre',
+                apellido: '$apellido',
+                direccion: {
+                    $arrayElemAt: [
+                        '$direccion.valor',
+                        0
+                    ]
+                },
+                fechaNacimiento: {
+                    $dateToString: {
+                        date: '$fechaNacimiento',
+                        format: '%d-%m-%Y',
+                        timezone: 'America/Argentina/Buenos_Aires'
+                    }
+                },
+                fecha: {
+                    $dateToString: {
+                        date: '$fecha',
+                        format: '%d-%m-%Y',
+                        timezone: 'America/Argentina/Buenos_Aires'
+                    }
+                },
+                idEfector: '$idEfector',
+                CodigoSisa: '$organizacion.codigo.sisa',
+                vacunas: '$vacuna',
+                fechaCarga: {
+                    $dateToString: {
+                        date: '$fecha',
+                        format: '%d-%m-%Y',
+                        timezone: 'America/Argentina/Buenos_Aires'
+                    }
+                },
+            }
+        }
+    ];
+    const prestaciones = await Prestacion.aggregate(pipelineVacunaCovid19);
+    for (let unaPrestacion of prestaciones) {
+        const data = {
+            ciudadano:
+            {
+                tipoDocumento: 1,
+                numeroDocumento: unaPrestacion.dni,
+                sexo: unaPrestacion.sexo === 'femenino' ? 'F' : (unaPrestacion.sexo === 'masculino') ? 'M' : '',
+                nombre: unaPrestacion.nombre,
+                apellido: unaPrestacion.apellido,
+                fechaNacimiento: unaPrestacion.fechaNacimiento,
+                calle: unaPrestacion.direccion ? unaPrestacion.direccion : '',
+                pais: 200,
+                provincia: 15,
+                departamento: 365  // Confluencia, luego updetear por el que corresponda
+            },
+            aplicacionVacuna:
+            {
+                establecimiento: unaPrestacion.CodigoSisa,
+                fechaAplicacion: unaPrestacion.vacunas[0].fechaAplicacion ? moment(unaPrestacion.vacunas[0].fechaAplicacion).format('DD-MM-YYYY') : null,
+                lote: unaPrestacion.vacunas[0].lote,
+                esquema: unaPrestacion.vacunas[0].esquema.codigo,
+                condicionAplicacion: unaPrestacion.vacunas[0].condicion.codigo,
+                vacuna: unaPrestacion.vacunas[0].vacuna.codigo,
+                ordenDosis: unaPrestacion.vacunas[0].dosis.codigo,
+                referenciaSistemaProvincial: '32342'   // faltaría ver bien que es esto, aunque no es obligatorio
+            }
+        };
+        const dto = {
+            username: user,
+            password: clave,
+            ciudadano: data.ciudadano,
+            aplicacionVacuna: data.aplicacionVacuna
+        };
+
+        let log = {
+            fecha: new Date(),
+            sistema: 'Nomivac',
+            key: unaPrestacion.tipo,
+            idPaciente: unaPrestacion.idPaciente,
+            info_enviada: data,
+            resultado: {}
+        };
+        try {
+            const options = {
+                uri: urlSisa,
+                method: 'POST',
+                body: dto,
+                headers: { 'Content-Type': 'application/json' },
+                json: true,
+            };
+            const resJson = await handleHttpRequest(options);
+            if (resJson && resJson.length > 0) {
+                const code = resJson[0];
+                const response = resJson[1];
+                log.resultado = {
+                    status: code ? code : '',
+                    resultado: response.resultado ? response.resultado : '',
+                    description: response.description ? response.description : '',
+                    error: response.errors ? response.errors : ''
+                };
+
+            } else {
+                log.resultado = {
+                    resultado: 'ERROR_DE_ENVIO',
+                    status: '',
+                    description: 'No se recibió ningún resultado'
+                };
+            }
+            let info = new InformacionExportada(log);
+            await info.save();
+
+        } catch (error) {
+            log.resultado = {
+                resultado: 'ERROR_DE_ENVIO',
+                status: 500,
+                description: error.toString()
+            };
+            let info = new InformacionExportada(log);
+            await info.save();
+        }
+    }
+    done();
+}

--- a/jobs/jobExportVacunaCovid19.ts
+++ b/jobs/jobExportVacunaCovid19.ts
@@ -1,0 +1,10 @@
+import { exportCovid19 } from './exportCovid19';
+
+function run(done) {
+    // Cantidad de horas inicio Ej: Si quiero todas las prestaciones desde hace 6 horas hasta este momento, envio el número 6.
+    const horas = process.env.HORAS || '1';
+    exportCovid19(done, parseInt(horas, 10));
+}
+
+export = run;
+


### PR DESCRIPTION
- Permite realizar el envío a nomivac en función de los datos cargados en la prestación de vacunación covid19
- Se almacena los datos en los logs sobre lo que se envió y las respuestas de nomivac.
- Cuando se invoque desde un job en forma automática, se deberá enviar una varible de entorno HORAS con la cantidad de horas que se quiera tomar hacia atrás.
- Se realiza control (filtro) en authUser para el login. Ya que debería tomar los usuarios activos.


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No

