### PR TITLE
fix(drive): ajustes file adapter

### DIFF
--- a/packages/drive/adapters/FileAdapter.ts
+++ b/packages/drive/adapters/FileAdapter.ts
@@ -6,18 +6,18 @@ import { Types } from 'mongoose';
 export class FileAdapter implements IAdapter {
     public name = 'file-adapter';
     private folder;
-    constructor ({ folder }) {
+    constructor({ folder }) {
         this.folder = folder;
     }
 
-    private folderName(name) {
+    private folderName(name: string) {
         return path.join(this.folder, name);
     }
 
-    write (stream: NodeJS.WriteStream): Promise<string> {
+    write(stream: NodeJS.WriteStream): Promise<string> {
         return new Promise((resolve, reject) => {
             const id = Types.ObjectId();
-            const p = this.folderName(id);
+            const p = this.folderName(String(id));
             const file = fs.createWriteStream(p);
             stream.pipe(file);
             stream.on('end', () => {
@@ -37,7 +37,7 @@ export class FileAdapter implements IAdapter {
         });
     }
 
-    delete (uuid: string): Promise<void> {
+    delete(uuid: string): Promise<void> {
         return new Promise((resolve, reject) => {
             const p = this.folderName(uuid);
             fs.unlink(p, (err) => {


### PR DESCRIPTION
### Requerimiento
Pequeño ajuste para que funcione Andes Drive con el adaptador de archivos directo al disco rígido. Útil para probar los test o si no se quiere Seaweed en alguna versión de prueba. 

### UserStories llegó a completarse
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No
