### PR TITLE
fix(rup): adjuntos desde andes drive

### DIFF
--- a/modules/descargas/informe-rup/elementos-rup/adjuntar-documento.component.ts
+++ b/modules/descargas/informe-rup/elementos-rup/adjuntar-documento.component.ts
@@ -1,6 +1,7 @@
 import { HTMLComponent } from '../../model/html-component.class';
 import * as mime from 'mime-types';
 import { streamToBase64, readFile } from '../../../../core/tm/controller/file-storage';
+import { getArchivoAdjunto } from '../../../../modules/rup/controllers/rup';
 
 
 export class AdjuntarDocumentoComponent extends HTMLComponent {
@@ -43,8 +44,8 @@ export class AdjuntarDocumentoComponent extends HTMLComponent {
             .map(documento => {
                 return new Promise(async (resolve, reject) => {
                     if (documento.id) {
-                        const archivo = await readFile(documento.id, 'RupStore');
-                        const base64 = await streamToBase64(archivo.stream);
+                        const stream = await getArchivoAdjunto(documento.id);
+                        const base64 = await streamToBase64(stream);
                         return resolve({ img: base64, term: documento?.descripcion?.term });
                     }
                     return;

--- a/modules/descargas/routes/descargas.ts
+++ b/modules/descargas/routes/descargas.ts
@@ -11,7 +11,7 @@ import { RecuperoCosto } from '../recupero-costo/recupero-costo';
 import { ConstanciaPuco } from '../puco/constancia-puco';
 import { Derivacion } from '../com/derivacion';
 import { Arancelamiento } from '../arancelamiento/arancelamiento';
-import { readFile } from '../../../core/tm/controller/file-storage';
+import { getArchivoAdjunto } from '../../../modules/rup/controllers/rup';
 
 const router = express.Router();
 
@@ -106,9 +106,9 @@ router.post('/send/:tipo', Auth.authenticate(), async (req, res, next) => {
         const fecha = moment(handlebarsData.fechaInicio).format('DD-MM-YYYY-H-mm-ss');
         for (const adj of adjuntos) {
             count++;
-            const data = await readFile(adj.id, 'RupStore');
+            const stream = await getArchivoAdjunto(adj.id);
             attachments.push({
-                content: data.stream,
+                content: stream,
                 filename: `adjunto_${count} - ${fecha}.${adj.ext}`
             });
         }

--- a/modules/rup/controllers/rup.ts
+++ b/modules/rup/controllers/rup.ts
@@ -1,6 +1,9 @@
 import * as mongoose from 'mongoose';
 import * as moment from 'moment';
 import { Prestacion } from '../schemas/prestacion';
+import { ObjectId } from '@andes/core';
+import { AndesDrive } from '@andes/drive/';
+import { readFile } from '../../../core/tm/controller/file-storage';
 
 /**
  * Función recursiva que permite recorrer un objeto y todas sus propiedades
@@ -197,4 +200,16 @@ export function matchConcepts(registro, conceptos) {
         });
     }
     return match;
+}
+
+
+export async function getArchivoAdjunto(id: ObjectId) {
+    const fileDrive = await AndesDrive.find(id);
+    if (fileDrive) {
+        const stream1 = await AndesDrive.read(fileDrive);
+        return stream1;
+    } else {
+        const data = await readFile(id, 'RupStore');
+        return data.stream;
+    }
 }


### PR DESCRIPTION
### Requerimiento
Los nuevos adjuntos de RUP están dirigidos a Andes Drive pero faltaban porciones de código por editar. 


### UserStories llegó a completarse 
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos 
- [ ] Si
- [x] No

 