### PR TITLE
fix(mpi): controla error de tamaño de la foto

### DIFF
--- a/core-v2/mpi/paciente/paciente.controller.ts
+++ b/core-v2/mpi/paciente/paciente.controller.ts
@@ -1,16 +1,16 @@
+import { Types } from 'mongoose';
 import { Paciente, replaceChars } from './paciente.schema';
 import * as moment from 'moment';
-import { Types } from 'mongoose';
 import { Matching } from '@andes/match';
 import { IPacienteDoc, IPaciente } from './paciente.interface';
 import { isSelected } from '@andes/core';
-import * as config from '../../../config';
 import { getObraSocial } from '../../../modules/obraSocial/controller/obraSocial';
 import { PacienteCtr } from './paciente.routes';
 import { geoReferenciar, getBarrio } from '@andes/georeference';
 import * as Barrio from '../../../core/tm/schemas/barrio';
 import * as configPrivate from '../../../config.private';
-const ObjectId = Types.ObjectId;
+import * as config from '../../../config';
+
 /**
  * Crea un objeto paciente
  */
@@ -35,7 +35,7 @@ export function set(paciente: IPacienteDoc, body: any) {
     }
     paciente.set(body);
     if (paciente.foto && !paciente.fotoId) {
-        (paciente as any).fotoId = new ObjectId();
+        (paciente as any).fotoId = new Types.ObjectId();
     }
     return paciente;
 }


### PR DESCRIPTION

### Requerimiento
Agrega try catch para controlar error de resize de la foto que viene desde renaper

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. 
2. 
3. 


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
