### PR TITLE
feat(inscripcion-vacunacion): Agrega eventos para actualizar inscripción

### DIFF
--- a/modules/rup/routes/prestacion.ts
+++ b/modules/rup/routes/prestacion.ts
@@ -683,18 +683,36 @@ EventCore.on('rup:prestacion:validate', async (prestacion) => {
 
 EventCore.on('rup:prestacion:validate', async (prestacion: IPrestacionDoc) => {
     const elementosRUPSet = await elementosRUPAsSet();
-
     const registros = prestacion.getRegistros(true);
 
     for (const reg of registros) {
 
+        if (reg.elementoRUP) {
+            const elemento = elementosRUPSet.getByID(reg.elementoRUP);
+            if (elemento && elemento.dispatch) {
+                elemento.dispatch.forEach(hook => {
+                    if (hook.method === 'validar-prestacion') {
+                        EventCore.emitAsync(hook.event, { prestacion, registro: reg });
+                    }
+                });
+            }
+        }
+    }
+});
 
+EventCore.on('rup:prestacion:romperValidacion', async (prestacion: IPrestacionDoc) => {
+    const elementosRUPSet = await elementosRUPAsSet();
+    const registros = prestacion.getRegistros(true);
+
+    for (const reg of registros) {
         if (reg.elementoRUP) {
 
             const elemento = elementosRUPSet.getByID(reg.elementoRUP);
             if (elemento && elemento.dispatch) {
                 elemento.dispatch.forEach(hook => {
-                    EventCore.emitAsync(hook.event, { prestacion, registro: reg });
+                    if (hook.method === 'romper-validacion') {
+                        EventCore.emitAsync(hook.event, { prestacion, registro: reg });
+                    }
                 });
             }
         }

--- a/modules/rup/schemas/elementoRUP.ts
+++ b/modules/rup/schemas/elementoRUP.ts
@@ -26,6 +26,7 @@ export interface IElementoRUP {
     permiteRepetidos?: boolean;
     dispatch?: {
         event: string;
+        method: string;
     }[];
 }
 
@@ -158,7 +159,8 @@ export const ElementoRUPSchema = new mongoose.Schema({
     },
     rules: [mongoose.SchemaTypes.Mixed],
     dispatch: [{
-        event: String
+        event: String,
+        method: String
     }]
 });
 

--- a/modules/vacunas/controller/inscripcion-vacunas.events.ts
+++ b/modules/vacunas/controller/inscripcion-vacunas.events.ts
@@ -49,6 +49,7 @@ EventCore.on('vacunas:inscripcion:vacunado', async ({ prestacion }, req: Request
     const inscripto = await InscripcionVacunasCtr.findOne({ idPaciente: prestacion.paciente.id });
     if (inscripto) {
         inscripto.fechaVacunacion = prestacion.ejecucion.fecha;
+        inscripto.idPrestacionVacuna = prestacion._id;
         await InscripcionVacunasCtr.update(inscripto.id, inscripto, req);
     }
 });
@@ -58,6 +59,7 @@ EventCore.on('vacunas:inscripcion:cancelar-vacunado', async ({ prestacion }, req
     const inscripto = await InscripcionVacunasCtr.findOne({ idPaciente: prestacion.paciente.id });
     if (inscripto) {
         inscripto.fechaVacunacion = null;
+        inscripto.idPrestacionVacuna = null;
         await InscripcionVacunasCtr.update(inscripto.id, inscripto, req);
     }
 });

--- a/modules/vacunas/controller/inscripcion-vacunas.events.ts
+++ b/modules/vacunas/controller/inscripcion-vacunas.events.ts
@@ -43,3 +43,22 @@ EventCore.on('vacunas:inscripcion-vacunas:create', async (inscripto: any, inscri
     await InscripcionVacunasCtr.update(inscripto.id, inscripto, req);
 
 });
+
+// Al validar la prestacion de vacunacion, inserta la fecha de vacunacion en la inscripcion
+EventCore.on('vacunas:inscripcion:vacunado', async ({ prestacion }, req: Request) => {
+    const inscripto = await InscripcionVacunasCtr.findOne({ idPaciente: prestacion.paciente.id });
+    if (inscripto) {
+        inscripto.fechaVacunacion = prestacion.ejecucion.fecha;
+        await InscripcionVacunasCtr.update(inscripto.id, inscripto, req);
+    }
+});
+
+// Quita la fecha de vacunacion si se rompe la validacion
+EventCore.on('vacunas:inscripcion:cancelar-vacunado', async ({ prestacion }, req: Request) => {
+    const inscripto = await InscripcionVacunasCtr.findOne({ idPaciente: prestacion.paciente.id });
+    if (inscripto) {
+        inscripto.fechaVacunacion = null;
+        await InscripcionVacunasCtr.update(inscripto.id, inscripto, req);
+    }
+});
+

--- a/modules/vacunas/inscripcion-vacunas.routes.ts
+++ b/modules/vacunas/inscripcion-vacunas.routes.ts
@@ -19,7 +19,11 @@ class InscripcionVacunasResource extends ResourceBase {
         documento: MongoQuery.equalMatch,
         nombre: MongoQuery.partialString,
         apellido: MongoQuery.partialString,
-        sexo: MongoQuery.equalMatch
+        sexo: MongoQuery.equalMatch,
+        idPaciente: {
+            field: 'paciente.id',
+            fn: MongoQuery.equalMatch
+        }
     };
     eventBus = EventCore;
 }

--- a/modules/vacunas/schemas/inscripcion-vacunas.schema.ts
+++ b/modules/vacunas/schemas/inscripcion-vacunas.schema.ts
@@ -45,7 +45,19 @@ export const InscripcionVacunaSchema = new Schema({
     localidadEstablecimiento: { type: nombreSchema },
     relacion: String,
     diaseleccionados: String,
-    fechaVacunacion: Date
+    fechaVacunacion: Date,
+    idPrestacionVacuna: Types.ObjectId
+});
+
+InscripcionVacunaSchema.index({
+    'paciente.id': 1
+});
+InscripcionVacunaSchema.index({
+    fechaRegistro: 1
+});
+InscripcionVacunaSchema.index({
+    documento: 1,
+    sexo: 1
 });
 
 export const InscripcionVacuna = model('inscripcion-vacuna', InscripcionVacunaSchema, 'inscripcion-vacunas');

--- a/modules/vacunas/schemas/inscripcion-vacunas.schema.ts
+++ b/modules/vacunas/schemas/inscripcion-vacunas.schema.ts
@@ -44,7 +44,8 @@ export const InscripcionVacunaSchema = new Schema({
     establecimiento: String,
     localidadEstablecimiento: { type: nombreSchema },
     relacion: String,
-    diaseleccionados: String
+    diaseleccionados: String,
+    fechaVacunacion: Date
 });
 
 export const InscripcionVacuna = model('inscripcion-vacuna', InscripcionVacunaSchema, 'inscripcion-vacunas');


### PR DESCRIPTION
### Requerimiento

- En el momento que se valida la prestación de vacunación de un inscripto, agregar el campo fechaVacunacion a la inscripcion para poder realizar consultas de manera eficiente.
- Si rompen una validación que ya impacto la fecha de vacunación en la inscripcion, limpiar dicho campo

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se agregaron los eventos correspondientes en inscripcion-vacunas

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [x] Si
- [ ] No

En el elementoRup de vacunasComponent, agregar el siguiente campo:
"dispatch" : [ 
        {
            "event" : "vacunas:inscripcion:vacunado",
            "method" : "validar-prestacion"
        }, 
        {
            "event" : "vacunas:inscripcion:cancelar-vacunado",
            "method" : "romper-validacion"
        }
    ],