### PR TITLE
fix(pecas): quita control de segundo parametro de eachAsync

### DIFF
--- a/modules/estadistica/controller/procesarFueraDeAgenda.ts
+++ b/modules/estadistica/controller/procesarFueraDeAgenda.ts
@@ -47,7 +47,7 @@ export async function procesar(parametros: any) {
         const resultado = [];
         let os = parametros.financiador ? parametros.financiador : 'todos';
         let filtroEstado = parametros.estado ? parametros.estado : 'todos';
-        await prestaciones.eachAsync(async (prestacion, error) => {
+        await prestaciones.eachAsync(async (prestacion) => {
             let filtroOS = false;
             let dtoPrestacion = {
                 fecha: prestacion.ejecucion.fecha,
@@ -83,9 +83,6 @@ export async function procesar(parametros: any) {
 
             if (filtroOS === true && (filtroEstado === dtoPrestacion.estado || filtroEstado === 'todos')) {
                 resultado.push(dtoPrestacion);
-            }
-            if (error) {
-                return error;
             }
         });
         return resultado;

--- a/modules/estadistica/pecas/controller/fueraDeAgenda.ts
+++ b/modules/estadistica/pecas/controller/fueraDeAgenda.ts
@@ -95,10 +95,7 @@ export async function fueraAgendaPecas(start, end, done) {
 
     try {
         const prestaciones = Codificacion.aggregate(pipeline2).cursor({ batchSize: 100 }).exec();
-        await prestaciones.eachAsync(async (prestacion, error) => {
-            if (error) {
-                return error;
-            }
+        await prestaciones.eachAsync(async (prestacion) => {
             await eliminaPrestacion(prestacion.idPrestacion);
             await auxiliar(prestacion);
         });


### PR DESCRIPTION
### Requerimiento
Revisar porque no se están pasando a Pecas las prestaciones fuera de agenda

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se elimina segundo parámetro del método eachAsync de mongoose ya que devolvía un indice y no un error (a partir de actualización en versión de mongoose)


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No

