### PR TITLE
HUDS:  Búsqueda por pacientes vinculados

### DIFF
--- a/modules/rup/routes/prestacion.ts
+++ b/modules/rup/routes/prestacion.ts
@@ -39,9 +39,12 @@ router.get('/prestaciones/huds/:idPaciente', async (req: any, res, next) => {
     }
 
     try {
-        // por defecto traemos todas las validadas, si no vemos el estado que viene en la request
+        const paciente: any = await PacienteCtr.findById(req.params.idPaciente);
+        if (!paciente) {
+            return res.status(404).send('Paciente no encontrado');
+        }
         const query = {
-            'paciente.id': req.params.idPaciente,
+            'paciente.id': { $in: paciente.vinculos },
             'estadoActual.tipo': req.query.estado ? req.query.estado : 'validada'
         };
 


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/RUP-244

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se agrega a la ruta `/prestaciones/huds/:idPaciente` la búsqueda por vinculados.

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No

### Observacion
- Si bien la US marca que se agregue la búsqueda por vinculados en la ruta de vacunas, no se pudo realizar porque en la colección nomivac no se registra el id del paciente sino que se hace por documento.
