### PR TITLE
VAC: nuevos eventos al validar o romper validación de certificación

### DIFF
--- a/modules/vacunas/schemas/inscripcion-vacunas.schema.ts
+++ b/modules/vacunas/schemas/inscripcion-vacunas.schema.ts
@@ -55,6 +55,8 @@ export const InscripcionVacunaSchema = new Schema({
     morbilidades: [String],
     fechaValidacion: Date,
     localidadDeclarada: String,
+    fechaCertificado: Date,
+    idPrestacionCertificado: Types.ObjectId
 });
 
 InscripcionVacunaSchema.index({


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/VAC-16

### Funcionalidad desarrollada 
1. Cuando se valida o se rompe la validación de la prestación **certificación de paciente con riesgo aumentado de COVID-19**, se actualizan los campos fechaCertificado e idPrestacionCertificado en inscripcion-vacunas

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [X] Si
- [ ] No

En el elementoRup de certificación de paciente con riesgo aumentado de COVID-19, agregar el siguiente campo:

"dispatch" : [ 
        {
            "event" : "vacunas:inscripcion:certificado",
            "method" : "validar-prestacion"
        }, 
        {
            "event" : "vacunas:inscripcion:cancelar-certificado",
            "method" : "romper-validacion"
        }
    ]
