### PR TITLE
VACUNACION: Agrega parametros fecha desde y hasta al exportVacuna

### DIFF
--- a/jobs/exportCovid19.ts
+++ b/jobs/exportCovid19.ts
@@ -6,9 +6,9 @@ import { sisa } from './../config.private';
 
 const urlSisa = sisa.url_nomivac;
 
-export async function exportCovid19(done, horas) {
-    const start = moment().subtract(horas, 'h').toDate();
-    const end = moment().toDate();
+export async function exportCovid19(done, horas, desde, hasta) {
+    const start = desde ? moment(desde).toDate() : moment().subtract(horas, 'h').toDate();
+    const end = hasta ? moment(hasta).toDate() : moment().toDate();
     const pipelineVacunaCovid19 = [
         {
             $match: {
@@ -145,7 +145,7 @@ export async function exportCovid19(done, horas) {
                 uri: urlSisa,
                 method: 'POST',
                 body: dto,
-                headers: { APP_ID: sisa.APP_ID_ALTA, APP_KEY: sisa.APP_KEY_ALTA , 'Content-Type': 'application/json' },
+                headers: { APP_ID: sisa.APP_ID_ALTA, APP_KEY: sisa.APP_KEY_ALTA, 'Content-Type': 'application/json' },
                 json: true,
             };
             const resJson = await handleHttpRequest(options);

--- a/jobs/jobExportVacunaCovid19.ts
+++ b/jobs/jobExportVacunaCovid19.ts
@@ -2,11 +2,15 @@ import { exportCovid19 } from './exportCovid19';
 
 
 function run(done) {
-    // Cantidad de horas inicio Ej: Si quiero todas las prestaciones desde hace 6 horas hasta este momento, envio el número 6.
-    const horas = process.env.HORAS || '1';
-    const desde = process.env.FECHADESDE;
-    const hasta = process.env.FECHAHASTA;
-    exportCovid19(done, parseInt(horas, 10), desde, hasta);
+    // Si length=5 entonces vienen dos argumentos (fechaDesde y fechaHasta)
+    if (process.argv.length === 5) {
+        const desde = process.argv[3];
+        const hasta = process.argv[4];
+        exportCovid19(done, null, desde, hasta);
+    } else { // Si no es 5 entonces viene 1 solo argumento (horas) o sin argumentos (por defecto una hora)
+        const horas = process.argv[3] || '1';
+        exportCovid19(done, parseInt(horas, 10), null, null);
+    }
 }
 
 export = run;

--- a/jobs/jobExportVacunaCovid19.ts
+++ b/jobs/jobExportVacunaCovid19.ts
@@ -1,9 +1,12 @@
 import { exportCovid19 } from './exportCovid19';
 
+
 function run(done) {
     // Cantidad de horas inicio Ej: Si quiero todas las prestaciones desde hace 6 horas hasta este momento, envio el número 6.
     const horas = process.env.HORAS || '1';
-    exportCovid19(done, parseInt(horas, 10));
+    const desde = process.env.FECHADESDE;
+    const hasta = process.env.FECHAHASTA;
+    exportCovid19(done, parseInt(horas, 10), desde, hasta);
 }
 
 export = run;


### PR DESCRIPTION
### Requerimiento
Permitir hacer la exportación por fecha desde y hasta en el job _exportCovid19_

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se agregan las constantes desde y hasta para enviar en caso que se desee a la funcion _exportCovid19_
2. Dentro de la función _exportCovid19_ se agrega ternaria para chequear en caso que venga por parámetro una fecha "desde" se setea la constanste `start` con dicha fecha, caso contrario se setean las horas enviadas o 1 hora en el caso que es el caso default.
3. Dentro de la funcion _exportCovid19_ se agrega ternaria para chequear en caso que venga por parámetro una fecha "hasta" se setea la constante `end` con dicha fecha, caso contrario se setea la constante con la fecha y hora actual.


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No

