### PR TITLE
feat(vacunas): TAG vacunasCovid en prestaciones

### DIFF
--- a/modules/rup/prestaciones.interface.ts
+++ b/modules/rup/prestaciones.interface.ts
@@ -33,6 +33,7 @@ export interface IPrestacion {
     };
 
     solicitud: IPrestacionSolicitud;
+    tags?: any;
 
 }
 

--- a/modules/rup/routes/prestacion.ts
+++ b/modules/rup/routes/prestacion.ts
@@ -692,12 +692,21 @@ EventCore.on('rup:prestacion:validate', async (prestacion: IPrestacionDoc) => {
 
         if (reg.elementoRUP) {
             const elemento = elementosRUPSet.getByID(reg.elementoRUP);
+
             if (elemento && elemento.dispatch) {
                 elemento.dispatch.forEach(hook => {
                     if (hook.method === 'validar-prestacion') {
                         EventCore.emitAsync(hook.event, { prestacion, registro: reg });
                     }
                 });
+            }
+            if (elemento && elemento.tags) {
+                const tags = {};
+                elemento.tags.forEach(tag => {
+                    tags[tag] = true;
+                });
+                prestacion.tags = tags;
+                await prestacion.save();
             }
         }
     }

--- a/modules/rup/routes/prestacion.ts
+++ b/modules/rup/routes/prestacion.ts
@@ -688,11 +688,10 @@ EventCore.on('rup:prestacion:validate', async (prestacion: IPrestacionDoc) => {
     const elementosRUPSet = await elementosRUPAsSet();
     const registros = prestacion.getRegistros(true);
 
+    let tags = {};
     for (const reg of registros) {
-
         if (reg.elementoRUP) {
             const elemento = elementosRUPSet.getByID(reg.elementoRUP);
-
             if (elemento && elemento.dispatch) {
                 elemento.dispatch.forEach(hook => {
                     if (hook.method === 'validar-prestacion') {
@@ -701,15 +700,13 @@ EventCore.on('rup:prestacion:validate', async (prestacion: IPrestacionDoc) => {
                 });
             }
             if (elemento && elemento.tags) {
-                const tags = {};
                 elemento.tags.forEach(tag => {
                     tags[tag] = true;
                 });
-                prestacion.tags = tags;
-                await prestacion.save();
             }
         }
     }
+    await Prestacion.updateOne( { _id: prestacion.id} , { $set: { tags } });
 });
 
 EventCore.on('rup:prestacion:romperValidacion', async (prestacion: IPrestacionDoc) => {

--- a/modules/rup/schemas/elementoRUP.ts
+++ b/modules/rup/schemas/elementoRUP.ts
@@ -28,6 +28,7 @@ export interface IElementoRUP {
         event: string;
         method: string;
     }[];
+    tags?: string[];
 }
 
 export type IElementoRUPDoc = AndesDoc<IElementoRUP>;
@@ -161,7 +162,8 @@ export const ElementoRUPSchema = new mongoose.Schema({
     dispatch: [{
         event: String,
         method: String
-    }]
+    }],
+    tags: [String]
 });
 
 ElementoRUPSchema.plugin(AuditPlugin);

--- a/modules/rup/schemas/prestacion.ts
+++ b/modules/rup/schemas/prestacion.ts
@@ -146,6 +146,7 @@ export const PrestacionSchema = new Schema({
         elementoRUP: SchemaTypes.ObjectId
 
     },
+    tags: Schema.Types.Mixed,
     // Historia de estado de la prestación
     estados: [PrestacionEstadoSchema],
     estadoActual: PrestacionEstadoSchema

--- a/scripts/tag-vacunas.ts
+++ b/scripts/tag-vacunas.ts
@@ -1,0 +1,31 @@
+import { Prestacion } from './../modules/rup/schemas/prestacion';
+
+async function run(done) {
+    const parametros = {
+        'ejecucion.fecha': {$gt: new Date('2020-12-27T00:00:00.000-03:00')},
+        'estadoActual.tipo': 'validada',
+        'ejecucion.registros.concepto.conceptId': '840534001',
+        'tags.vacunasCovid': {$exists: false}
+    };
+
+    const prestaciones = Prestacion.find(parametros).cursor({ batchSize: 100 });
+    let i = 0;
+    for await (const prestacion of prestaciones) {
+        i++;
+        // tslint:disable-next-line:no-console
+        if (i % 100 === 0) { console.log(i); }
+
+        const $set: any = {
+            tags: {vacunasCovid: true},
+        };
+        await Prestacion.update(
+            { _id: prestacion.id },
+            { $set }
+        );
+
+    }
+    done();
+}
+
+export = run;
+


### PR DESCRIPTION
### Requerimiento

- Script para tagear las prestaciones correspondientes a vacunación covid
- Agrega tags del elementoRUP en la prestación al momento de su validación

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Script
2. Campo nuevo en prestaciones

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [x] Si - db.getCollection('elementosRUP').update({componente:'VacunasComponent'}, {$set:{tags:['vacunasCovid']}})
- [ ] No

