### PR TITLE
INSCRIPCION-PROFESIONALES: Campo solo profesionales matriculados

### DIFF
--- a/core/tm/routes/profesional.ts
+++ b/core/tm/routes/profesional.ts
@@ -1227,7 +1227,7 @@ router.post('/profesionales/validar', async (req, res, next) => {
     const resRenaper = await renaperv3({ documento, sexo }, busInteroperabilidad, renaperToAndes);
     if (resRenaper && resRenaper.idTramite === Number(nroTramite)) {
         const regexSexo = new RegExp(['^', sexo, '$'].join(''), 'i');
-        const profesional = await Profesional.findOne({ documento, sexo: regexSexo });
+        const profesional = await Profesional.findOne({ documento, sexo: regexSexo, profesionalMatriculado: true });
         const token = await getTemporyTokenCOVID(documento);
         return profesional ? res.json({ profesional, token }) : next(`El profesional no se encuentra registrado en Andes.`);
     } else {


### PR DESCRIPTION
### Requerimiento
Fix para profesionales duplicados en la base de datos.

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se agrega el campo _profesionalMatriculado: true_ en la búsqueda de profesionales para que esta solo traiga los profesionales que se encuentren registrado en matriculaciones.


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [X] No

