### PR TITLE
fix(script VAC-9): reemplaza save por updateOne

### DIFF
--- a/scripts/VAC-9.ts
+++ b/scripts/VAC-9.ts
@@ -9,9 +9,7 @@ async function ActualizarInscripciones() {
             const prestaciones: any[] = await Prestacion.find({ 'ejecucion.registros.concepto.conceptId': '840534001', 'paciente.id': inscripcion.paciente.id });
             if (prestaciones.length) {
                 try {
-                    inscripcion.fechaVacunacion = prestaciones[0].ejecucion.fecha;
-                    inscripcion.idPrestacionVacuna = prestaciones[0].id;
-                    await inscripcion.save();
+                    await InscripcionVacuna.updateOne( { _id: inscripcion.id} , { $set: { fechaVacunacion: prestaciones[0].ejecucion.fecha, idPrestacionVacuna: prestaciones[0].id} });
                 } catch (e) {
                     return;
                 }


### PR DESCRIPTION
### Requerimiento
Corregir error en script que inserta fecha de vacunación e id en inscriptos

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. se reemplazó save por updateOne

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No

