### PR TITLE
fix(inscripcion): cambia control para el mensaje de consulta

### DIFF
--- a/modules/vacunas/controller/inscripcion.vacunas.controller.ts
+++ b/modules/vacunas/controller/inscripcion.vacunas.controller.ts
@@ -46,15 +46,15 @@ export async function mensajeEstadoInscripcion(documento: String, sexo: String) 
                 estadoInscripcion.body = 'Usted se encuentra en proceso de validación.';
                 estadoInscripcion.status = 'warning';
             }
-        }
-        if (!grupo.mensajeDefault && estadoInscripcion.body === '') {
-            estadoInscripcion.subtitulo = 'Su inscripción para la vacunación se encuentra habilitada';
-            estadoInscripcion.body = `Usted se encuentra habilitado para recibir la vacuna,
-            el turno será asignado cuando tengamos disponibilidad efectiva de dosis`;
-            estadoInscripcion.status = 'success';
-        } else {
-            if (grupo.mensajeDefault) {
-                estadoInscripcion = grupo.mensajeDefault;
+            if (!grupo.mensajeDefault && estadoInscripcion.body === '') {
+                estadoInscripcion.subtitulo = 'Su inscripción para la vacunación se encuentra habilitada';
+                estadoInscripcion.body = `Usted se encuentra habilitado para recibir la vacuna,
+                el turno será asignado cuando tengamos disponibilidad efectiva de dosis`;
+                estadoInscripcion.status = 'success';
+            } else {
+                if (grupo.mensajeDefault) {
+                    estadoInscripcion = grupo.mensajeDefault;
+                }
             }
         }
         estadoInscripcion.titulo = `Grupo: ${grupo.descripcion}`;


### PR DESCRIPTION

### Requerimiento
Cambia condición para que se visualice el mensaje de que el paciente recibió una dosis antes que los mensajes default configurados por grupo

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. 
2. 
3. 


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
