### PR TITLE
fix(inscripcion): control de nro de trámite

### DIFF
--- a/modules/vacunas/controller/inscripcion.vacunas.controller.ts
+++ b/modules/vacunas/controller/inscripcion.vacunas.controller.ts
@@ -22,7 +22,7 @@ export async function mensajeEstadoInscripcion(documento: String, sexo: String) 
     const inscripto = await InscripcionVacunasCtr.findOne({
         documento,
         sexo
-    });
+    }, { sort: '-fechaRegistro' });
     let estadoInscripcion: IEstadoInscripcion = { titulo: '', subtitulo: '', body: '', status: 'warning' };
     if (!inscripto) {
         estadoInscripcion.titulo = `Inscripción inexistente`;
@@ -93,7 +93,7 @@ async function verificarDomicilioInscripcion(inscripcion, validacion) {
             // se verifica el domicilio del paciente
             if (inscripcion.paciente && inscripcion.paciente.id) {
                 const paciente = await PacienteCtr.findById(inscripcion.paciente.id);
-                const domicilio = paciente.direccion.find(dir => dir.ubicacion.provincia.nombre && replaceChars(dir.ubicacion.provincia.nombre as any).toLowerCase() === validacion.provincia);
+                const domicilio = paciente.direccion.find(dir => dir.ubicacion.provincia?.nombre && replaceChars(dir.ubicacion.provincia?.nombre as any).toLowerCase() === validacion.provincia);
                 if (!domicilio) {
                     return validacion.mensajeError;
                 }


### PR DESCRIPTION

### Requerimiento
Modifica el momento en que se realiza el control de número de trámite
Si los datos ingresados del inscripto, son inferiores a la cota máxima establecida se verifica el número de trámite.  Caso contrario deja al inscripto continuar

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Agrega controles en la verificación del domicilio para la consulta
2. Permite ingresar un paciente si, existe algun registro previo no validado
3. 


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
