### PR TITLE
 BUSCADOR-EPIDEMIO: Historial de fichas

### DIFF
--- a/auth/permisos.ts
+++ b/auth/permisos.ts
@@ -670,6 +670,11 @@ export default [
                 key: 'read',
                 title: 'Visualizar ficha',
                 type: 'boolean'
+            },
+            {
+                key: 'historial',
+                title: 'Ver historial',
+                type: 'boolean'
             }
         ]
     }

--- a/initialize.ts
+++ b/initialize.ts
@@ -109,6 +109,7 @@ export function initAPI(app: Express) {
     app.use('/api/modules/perinatal', require('./modules/perinatal').CarnetPerinatalRouter);
     app.use('/api/core-v2/mpi', MPI.RoutingMPI);
     app.use('/api/modules/forms/forms-epidemiologia', require('./modules/forms/').FormEpidemiologiaRouter);
+    app.use('/api/modules/forms/forms-epidemiologia', require('./modules/forms/').FormHistoryRouter);
 
     if (configPrivate.hosts.BI_QUERY) {
         app.use(

--- a/modules/forms/forms-epidemiologia/forms-history.routes.ts
+++ b/modules/forms/forms-epidemiologia/forms-history.routes.ts
@@ -1,0 +1,18 @@
+import { MongoQuery, ResourceBase } from '@andes/core';
+import { FormsHistory } from './forms-history.schema';
+import { Auth } from '../../../auth/auth.class';
+
+class FormsHistoryResource extends ResourceBase {
+    Model = FormsHistory;
+    resourceName = 'formsHistory';
+    middlewares = [Auth.authenticate()];
+    searchFileds = {
+        idFicha: {
+            field: 'ficha._id',
+            fn: MongoQuery.equalMatch
+        },
+    };
+}
+
+export const FormHistoryCtr = new FormsHistoryResource();
+export const FormHistoryRouter = FormHistoryCtr.makeRoutes();

--- a/modules/forms/forms-epidemiologia/forms-history.schema.ts
+++ b/modules/forms/forms-epidemiologia/forms-history.schema.ts
@@ -1,0 +1,12 @@
+import { AuditPlugin } from '@andes/mongoose-plugin-audit';
+import * as mongoose from 'mongoose';
+import { FormsEpidemiologiaSchema } from './forms-epidemiologia-schema';
+
+
+export const FormsHistorySchema = new mongoose.Schema({
+    ficha: FormsEpidemiologiaSchema
+});
+
+FormsHistorySchema.plugin(AuditPlugin);
+
+export const FormsHistory = mongoose.model('formsEpidemiologiaHistory', FormsHistorySchema, 'formsEpidemiologiaHistory');

--- a/modules/forms/index.ts
+++ b/modules/forms/index.ts
@@ -1,4 +1,5 @@
 export { FormEpidemiologiaRouter } from './forms-epidemiologia/forms-epidemiologia.routes';
 export { FormResourcesRouter } from './forms-resources/forms-resources-routes';
 export { FormRouter } from './forms.routes';
+export { FormHistoryRouter } from './forms-epidemiologia/forms-history.routes';
 require('./forms-epidemiologia/forms-epidemiologia.events');


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/EP-42

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se agrega el nuevo permiso al modulo "Epidemiología" para ver el historial de una ficha.
2. Se agrega Schema y ResourceBase correspondiente a la nueva colección formsEpidemiologiaHistory donde se guardarán entradas del historial de fichas.


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [x] Si Agregar en el sumodulo "buscador fichas" que esta dentro del modulo "Epidemiología" el permiso " "epidemiologia:historial:?"
- [ ] No
