### PR TITLE
fix(inscripcion): quita doble llamado al evento create

### DIFF
--- a/modules/vacunas/controller/inscripcion.vacunas.controller.ts
+++ b/modules/vacunas/controller/inscripcion.vacunas.controller.ts
@@ -187,16 +187,18 @@ export async function validarInscripcion(inscripcion, inscriptoValidado, req) {
         if (!inscriptoValidado) {
             inscriptoValidado = await validar(inscripcion.documento, inscripcion.sexo);
         }
-        const value = await matching(inscriptoValidado, inscripcion);
-        if (value < mpi.cotaMatchMax) {
-            inscripcion.validado = false;
-        } else {
-            await extractFoto(inscriptoValidado, req);
-            paciente = await findOrCreate(inscriptoValidado, req);
-            if (paciente && paciente.id) {
-                inscripcion.paciente = paciente;
-                inscripcion.paciente.id = paciente.id;
-                inscripcion.validado = true;
+        if (inscriptoValidado) {
+            const value = await matching(inscriptoValidado, inscripcion);
+            if (value < mpi.cotaMatchMax) {
+                inscripcion.validado = false;
+            } else {
+                await extractFoto(inscriptoValidado, req);
+                paciente = await findOrCreate(inscriptoValidado, req);
+                if (paciente && paciente.id) {
+                    inscripcion.paciente = paciente;
+                    inscripcion.paciente.id = paciente.id;
+                    inscripcion.validado = true;
+                }
             }
         }
         inscripcion.fechaValidacion = new Date();

--- a/modules/vacunas/inscripcion-vacunas.routes.ts
+++ b/modules/vacunas/inscripcion-vacunas.routes.ts
@@ -185,7 +185,6 @@ InscripcionVacunasRouter.post('/inscripcion-vacunas/registro', async (req: Reque
             }
 
             const inscripcion = await InscripcionVacunasCtr.create(req.body, userScheduler as any);
-            EventCore.emitAsync('vacunas:inscripcion-vacunas:create', inscripcion, inscriptoValidado, req);
             return res.json(inscripcion);
         } else {
             return next('Existe una inscripción registrada. Verifique su estado en la página de consultas.');


### PR DESCRIPTION
### Requerimiento
Se quita la emisión del evento create de inscripción, ya que lo dispara a través del uso del controlador del resource base

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. 
2. 
3. 


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
