### PR TITLE
feat(epidemio): Agregamos el campo sexo al objeto paciente de la ficha

### DIFF
--- a/modules/forms/forms-epidemiologia/forms-epidemiologia-schema.ts
+++ b/modules/forms/forms-epidemiologia/forms-epidemiologia-schema.ts
@@ -1,6 +1,6 @@
 import { AuditPlugin } from '@andes/mongoose-plugin-audit';
-import { zonaSanitariasSchema } from '../../../core/tm/schemas/zonaSanitarias';
 import * as mongoose from 'mongoose';
+import { zonaSanitariasSchema } from '../../../core/tm/schemas/zonaSanitarias';
 
 export const FormsEpidemiologiaSchema = new mongoose.Schema({
     type: {
@@ -12,6 +12,7 @@ export const FormsEpidemiologiaSchema = new mongoose.Schema({
         documento: String,
         nombre: String,
         apellido: String,
+        sexo: String,
         fechaNacimiento: Date,
     },
     secciones: [Object],


### PR DESCRIPTION
1. Agregamos el campo sexo el objeto paciente dentro del esquema de la ficha de epidemio porque lo necesitamos para interoperar con Lab central.

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No


