### PR TITLE
AM: no validar trámite o captcha si es scan

### DIFF
--- a/auth/auth.class.ts
+++ b/auth/auth.class.ts
@@ -109,7 +109,7 @@ export class Auth {
 
     static validateCaptcha() {
         return async (req, res, next) => {
-            if (configPrivate.captcha.enabled) {
+            if (configPrivate.captcha.enabled && !req.body.scan) {
                 try {
                     const recaptcha = req.body.recaptcha;
                     if (!recaptcha) {


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/AM-154

### Funcionalidad desarrollada 
1. No validar captcha si es un scan de dni 

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [X] No

