### PR TITLE
fix(COM): Se soluciona el bug para que se envien los correos de derivaciones

### DIFF
--- a/modules/centroOperativoMedico/controllers/com.controller.ts
+++ b/modules/centroOperativoMedico/controllers/com.controller.ts
@@ -1,19 +1,17 @@
 import * as configPrivate from '../../../config.private';
-import * as SendEmail from '../../../utils/roboSender/sendEmail';
 import { Derivacion } from '../../../modules/descargas/com/derivacion';
+import * as SendEmail from '../../../utils/roboSender/sendEmail';
 const moment = require('moment');
 
-export async function sendMailComprobanteDerivacion(derivacion, email) {
-    let comprobante = new Derivacion({body: derivacion});
+export async function sendMailComprobanteDerivacion(derivacion, email, organizacionId) {
+    let comprobante = new Derivacion({ body: { derivacion, organizacionId } });
     const opciones = { header: { height: '3cm' } };
     const fileName: any = await comprobante.informe(opciones);
     const fechaFinalizacion = moment(derivacion.historial.createdAt).format('DD/MM/YYYY');
-
     let attachments = [{
         filename: `comprobante derivacion ${derivacion.paciente.nombre}${derivacion.paciente.apellido}-${fechaFinalizacion}.pdf`,
         path: fileName
     }];
-
     const handleBarsData = {
         asunto: 'Aviso de derivación finalizada',
         mensaje: `El paciente ${derivacion.paciente.nombre} ${derivacion.paciente.apellido}
@@ -31,6 +29,5 @@ export async function sendMailComprobanteDerivacion(derivacion, email) {
         html,
         attachments
     };
-
     SendEmail.sendMail(data);
 }

--- a/modules/centroOperativoMedico/derivaciones.routes.ts
+++ b/modules/centroOperativoMedico/derivaciones.routes.ts
@@ -62,9 +62,8 @@ DerivacionesRouter.post('/derivaciones/:id/historial', Auth.authenticate(), asyn
         const derivacion: any = await Derivaciones.findById(req.params.id);
         if (derivacion) {
             const nuevoEstado = req.body.estado;
-
             if (nuevoEstado.estado === 'habilitada') {
-                const orgCOM = (await Organizacion.find({esCOM: true}))[0];
+                const orgCOM = (await Organizacion.find({ esCOM: true }))[0];
                 const { id, nombre, direccion } = orgCOM;
                 nuevoEstado.organizacionDestino = { id, nombre, direccion };
                 delete nuevoEstado.unidadDestino;
@@ -74,7 +73,6 @@ DerivacionesRouter.post('/derivaciones/:id/historial', Auth.authenticate(), asyn
             if (nuevoEstado.prioridad) {
                 derivacion.prioridad = nuevoEstado.prioridad;
             }
-
             if (nuevoEstado.estado) {
                 const organizacionId = Auth.getOrganization(req);
                 const organizacion = await Organizacion.findById(organizacionId);
@@ -83,12 +81,11 @@ DerivacionesRouter.post('/derivaciones/:id/historial', Auth.authenticate(), asyn
                     return next('La derivación ya no está asignada a su organización');
                 }
                 derivacion.estado = nuevoEstado.estado;
-
                 const isPacienteDestino = derivacion.estado === 'finalizada' && derivacion.organizacionDestino && derivacion.organizacionDestino.id !== derivacion.organizacionOrigen.id;
                 if (isPacienteDestino && organizacion.esCOM && organizacion.configuraciones?.emails) {
                     const emailTo = organizacion.configuraciones.emails.find(e => e.nombre === 'recupero')?.email;
                     if (emailTo) {
-                        sendMailComprobanteDerivacion(derivacion, emailTo);
+                        sendMailComprobanteDerivacion(derivacion, emailTo, organizacionId);
                     }
                 }
             }
@@ -103,7 +100,6 @@ DerivacionesRouter.post('/derivaciones/:id/historial', Auth.authenticate(), asyn
                 derivacion.organizacionTraslado = req.body.trasladoEspecial.organizacionTraslado;
                 derivacion.tipoTraslado = req.body.trasladoEspecial.tipoTraslado;
             }
-
             Auth.audit(derivacion, req);
             await derivacion.save();
             return res.json(derivacion);

--- a/modules/descargas/com/derivacion-body.ts
+++ b/modules/descargas/com/derivacion-body.ts
@@ -212,7 +212,8 @@ export class DerivacionBody extends HTMLComponent {
     }
 
     public async process() {
-        const derivacion: any = await Derivaciones.findById(this._data.derivacionId);
+
+        const derivacion: any = await Derivaciones.findById(this._data._id);
 
         let finalizada = false;
         let elementoHistorial: any;
@@ -270,7 +271,7 @@ export class DerivacionBody extends HTMLComponent {
         historial.forEach(h => {
             h.fechaCreacion = moment(h.createdAt).locale('es').format('DD/MM/YYYY HH:mm');
             h.reporteCOM = organizacion.esCOM;
-            h.esActualizacion = !h?.estado;
+            h.esActualizacion = !h.estado;
         });
         return historial.sort((a, b) => b.createdAt - a.createdAt);
     }

--- a/modules/descargas/com/derivacion.ts
+++ b/modules/descargas/com/derivacion.ts
@@ -1,7 +1,6 @@
+import { getAssetsURL, InformePDF } from '../model/informe.class';
 import { DerivacionBody } from './derivacion-body';
 import { DerivacionHeader } from './derivacion-header';
-import { InformePDF, getAssetsURL } from '../model/informe.class';
-import { Auth } from '../../../auth/auth.class';
 
 export class Derivacion extends InformePDF {
     constructor(public req) {
@@ -14,10 +13,9 @@ export class Derivacion extends InformePDF {
 
     public async process() {
         this.header = new DerivacionHeader();
-
-        const { derivacionId, historial } = this.req.body;
-        const organizacionId = Auth.getOrganization(this.req);
-        this.body = new DerivacionBody({ derivacionId, historial, organizacionId });
+        const { _id, historial } = this.req.body.derivacion;
+        const organizacionId = this.req.body.organizacionId;
+        this.body = new DerivacionBody({ _id, historial, organizacionId });
         await super.process();
     }
 


### PR DESCRIPTION
1. Debido a un bug en el código hace 11 días que no se están enviando los comprobantes de derivación automáticamente.

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No

