### PR TITLE
feat(WEBHOOK): Agrega control por zona sanitaria para los sms de resultados covid

### DIFF
--- a/core-v2/mpi/paciente/paciente.controller.ts
+++ b/core-v2/mpi/paciente/paciente.controller.ts
@@ -408,3 +408,12 @@ export async function agregarHijo(progenitor, hijo, req) {
     }
 }
 
+export async function getLocalidad(paciente) {
+    if (paciente.direccion && paciente.direccion.length) {
+        const unaDireccion = paciente.direccion[0];
+        if (unaDireccion.ubicacion && unaDireccion.ubicacion.localidad) {
+            return unaDireccion.ubicacion.localidad;
+        }
+    }
+    return null;
+}

--- a/core/tm/controller/localidad.ts
+++ b/core/tm/controller/localidad.ts
@@ -40,8 +40,8 @@ export async function matchUbicacion(searchProvincia: string, searchLocalidad: s
 export async function getZona(idLocalidad) {
     let unaZona = null;
     const unaLocalidad: any = await localidad.findById(idLocalidad);
-    if (unaLocalidad.zonaSanitaria) {
-        unaZona = await ZonaSanitaria.findById(unaLocalidad.zonaSanitaria._id);
+    if (unaLocalidad.zona) {
+        unaZona = await ZonaSanitaria.findById(unaLocalidad.zona._id);
     }
     return unaZona;
 }

--- a/core/tm/controller/localidad.ts
+++ b/core/tm/controller/localidad.ts
@@ -2,6 +2,8 @@
 import * as localidad from '../schemas/localidad';
 import * as provincia from '../schemas/provincia_model';
 import { MatchingAndes } from '@andes/match/lib/matchingAndes.class';
+import { ZonaSanitaria } from '../schemas/zonaSanitarias';
+
 
 /**
  * Obtiene provincia y localidad desde DB a partir de un matching contra los params de entrada
@@ -29,4 +31,17 @@ export async function matchUbicacion(searchProvincia: string, searchLocalidad: s
         matchLocalidad = (match > matchLocalidad[0]) ? [match, unaLoc] : matchLocalidad;
     });
     return { provincia: matchProvincia[1], localidad: matchLocalidad[1] };
+}
+
+/**
+ * Obtiene zona sanitaria de una localidad
+ * @param localidad ObjectId de localidad
+ */
+export async function getZona(idLocalidad) {
+    let unaZona = null;
+    const unaLocalidad: any = await localidad.findById(idLocalidad);
+    if (unaLocalidad.zonaSanitaria) {
+        unaZona = await ZonaSanitaria.findById(unaLocalidad.zonaSanitaria._id);
+    }
+    return unaZona;
 }

--- a/core/tm/schemas/localidad.ts
+++ b/core/tm/schemas/localidad.ts
@@ -1,11 +1,13 @@
 import * as mongoose from 'mongoose';
 import * as provinciaSchema from './provincia';
+import { zonaSanitariasSchema } from './zonaSanitarias';
 
 const localidadSchema = new mongoose.Schema({
     nombre: String,
     codLocalidad: String,
     departamento: String,
-    provincia: { type: provinciaSchema }
+    provincia: { type: provinciaSchema },
+    zonaSanitaria: zonaSanitariasSchema
 });
 const localidad = mongoose.model('localidad', localidadSchema, 'localidad');
 export = localidad;

--- a/core/tm/schemas/localidad.ts
+++ b/core/tm/schemas/localidad.ts
@@ -7,7 +7,7 @@ const localidadSchema = new mongoose.Schema({
     codLocalidad: String,
     departamento: String,
     provincia: { type: provinciaSchema },
-    zonaSanitaria: zonaSanitariasSchema
+    zona: zonaSanitariasSchema
 });
 const localidad = mongoose.model('localidad', localidadSchema, 'localidad');
 export = localidad;

--- a/core/tm/schemas/zonaSanitarias.ts
+++ b/core/tm/schemas/zonaSanitarias.ts
@@ -1,7 +1,10 @@
 import { Schema, model } from 'mongoose';
 
 export const zonaSanitariasSchema = new Schema({
-    nombre: String
+    nombre: String,
+    configuracion: {
+        notificaciones: Boolean
+    }
 });
 
 

--- a/modules/webhook/webhook.routes.ts
+++ b/modules/webhook/webhook.routes.ts
@@ -47,7 +47,7 @@ WebhookRouter.post('/notification', Auth.authenticate(), asyncHandler(async (req
             }
             // filtrar zonas que no reciben notificaciones
             let enviarNotificacion = true;
-            const localidadPaciente: any = getLocalidad(paciente);
+            const localidadPaciente: any = await getLocalidad(paciente);
             const Zona = localidadPaciente && await getZona(localidadPaciente._id);
             if (Zona) {
                 enviarNotificacion = Zona.configuracion.notificaciones;


### PR DESCRIPTION
 
### Requerimiento
Poder configurar y filtrar por zonas sanitarias pacientes que reciben el mensaje de que esta listo su resultado de PCR

### Funcionalidad desarrollada 
1. Agregar la configuracion a la zona sanitaria
2. Agrega control en las notificaciones de si debe enviar o no el msn 


### UserStories llegó a completarse
- [ ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [ ] Si
- [ ] No

 