### PR TITLE
fix(inscripcion): quita excepción para mayores de 60

### DIFF
--- a/modules/vacunas/inscripcion-vacunas.routes.ts
+++ b/modules/vacunas/inscripcion-vacunas.routes.ts
@@ -185,8 +185,6 @@ InscripcionVacunasRouter.post('/inscripcion-vacunas/registro', async (req: Reque
     try {
         const documento = req.body.documento;
         const sexo = req.body.sexo;
-        req.body.nombre = req.body.nombre.toUpperCase();
-        req.body.apellido = req.body.apellido.toUpperCase();
 
         // Verifica si se encuentra inscripto previamente
         const inscripto = await InscripcionVacunasCtr.findOne({ documento, sexo, validado: true });
@@ -212,16 +210,17 @@ InscripcionVacunasRouter.post('/inscripcion-vacunas/registro', async (req: Reque
                 }
                 req.body.validado = true;
             } else {
-                if (req.body.grupo.nombre !== 'mayores60') {
-                    return next('No es posible verificar su identidad.  Por favor verifique sus datos');
-                }
+                return next('No es posible verificar su identidad.  Por favor verifique sus datos');
             }
             if (req.body.grupo.nombre === 'factores-riesgo' && (!req.body.morbilidades[0] && !req.body.factorRiesgoEdad)) {
                 return next('Seleccionar factor de riesgo asociado a vacunación');
             }
-            if (req.body.email) {
-                req.body.email = req.body.email.toLowerCase().trim();
-            }
+
+            req.body.email = req.body.email.toLowerCase().trim() || '';
+            // Asigna los datos básicos de la inscripcion
+            req.body.fechaNacimiento = inscriptoValidado.fechaNacimiento;
+            req.body.apellido = inscriptoValidado.apellido;
+            req.body.nombre = inscriptoValidado.nombre;
             const inscripcion = await InscripcionVacunasCtr.create(req.body, userScheduler as any);
             return res.json(inscripcion);
         } else {


### PR DESCRIPTION

### Requerimiento
Se quita el control para el grupo de adultos mayores, que permitía ingresar una inscripción sin validar los datos debido a que muchas personas con más de 70 años no habían realizado el cambio de documentación y no existía en Renaper.  Debido a la etapa actual de vacunación se quita dicho control debido a que ingresaba una gran cantidad de datos erróneos en ese grupo.

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. 
2. 
3. 


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
