### PR TITLE
fix(matriculaciones): verifica profesional duplicado al cargar un turno

### DIFF
--- a/modules/matriculaciones/routes/turnoSolicitado.ts
+++ b/modules/matriculaciones/routes/turnoSolicitado.ts
@@ -1,3 +1,4 @@
+import { Profesional } from '../../../core/tm/schemas/profesional';
 import * as express from 'express';
 import { turnoSolicitado } from '../schemas/turnoSolicitado';
 
@@ -6,11 +7,18 @@ import { turnoSolicitado } from '../schemas/turnoSolicitado';
 
 const router = express.Router();
 
-router.post('/turnoSolicitados', (req, res, next) => {
+router.post('/turnoSolicitados', async (req, res, next) => {
 
     // // // if (!Auth.check(req, 'matriculaciones:profesional:postProfesional')) {
     // // //     return next(403);
     // // // }
+    const doc = req.body.documento;
+    const sexo = req.body.sexo;
+    const profesional = await Profesional.findOne({ documento: doc, sexo, profesionalMatriculado: false });
+    if (profesional && profesional._id) {
+        req.body._id = profesional._id;
+        req.body.profesionalMatriculado = true;
+    }
     const newProfesional = new turnoSolicitado(req.body);
     newProfesional.save((err2) => {
         if (err2) {


### PR DESCRIPTION

### Requerimiento
Verifica si el profesional existe como no matriculado, cuando saca un turno para matricularse, así utiliza el mismo objectId que tenía previamente a matricularse.

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. 
2. 
3. 


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
