### PR TITLE
fix(huds): quita mapeo a objetos de prestaciones

### DIFF
--- a/modules/rup/controllers/prestacion.ts
+++ b/modules/rup/controllers/prestacion.ts
@@ -138,7 +138,7 @@ export async function hudsPaciente(pacienteID: ObjectId, expresion: string, idPr
         prestaciones = await AppCache.get(`huds-${pacienteID}`);
         if (!prestaciones) {
             prestaciones = await Prestacion.find(query);
-            prestaciones = prestaciones.map(p => p.toObject());
+            prestaciones = prestaciones.map(p => p.toJSON());
             AppCache.set(`huds-${pacienteID}`, prestaciones, 60 * 60);
         }
     } else {


### PR DESCRIPTION

### Requerimiento
En Registros del paciente no se visualizaban los gráficos de seguimiento de peso, monitorización de la talla, etc, debido a que la búsqueda en la huds de dichos conceptos no arroja ningún resultado

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se quita el mapeo de las prestaciones a objetos
2. 
3. 


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
