### PR TITLE
Epidemiología: Búsqueda id pcr

### DIFF
--- a/modules/forms/forms-epidemiologia/forms-epidemiologia.routes.ts
+++ b/modules/forms/forms-epidemiologia/forms-epidemiologia.routes.ts
@@ -30,7 +30,11 @@ class FormsEpidemiologiaResource extends ResourceBase {
         },
         identificadorPcr: {
             field: 'secciones.fields.identificadorpcr',
-            fn: MongoQuery.partialString
+            fn: (value) => {
+                return {
+                    $regex: value
+                };
+            }
         },
         codigoSisa: {
             field: 'secciones.fields.codigoSisa',


### PR DESCRIPTION
### Requerimiento
En el buscador de fichas, realizar la busqueda identificador PCR por expresion regular ya que cuando se escanea el codigo puede venir con una leyenda antes del numero.

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se modifica la busqueda del identificador pcr por el operador $regex


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No

