### PR TITLE
Seguimiento: Fix al guardar llamados

### DIFF
--- a/modules/seguimiento-paciente/seguimiento-pacientes.events.ts
+++ b/modules/seguimiento-paciente/seguimiento-pacientes.events.ts
@@ -69,9 +69,8 @@ EventCore.on('epidemiologia:seguimiento:create', async (data) => {
 
 EventCore.on('epidemiologia:prestaciones:validate', async (data) => {
     try {
-        const seguimientos = await SeguimientoPaciente.find({ 'paciente.id': data.paciente.id }).sort({ createdAt: -1 });
-        if (seguimientos) {
-            const lastSeguimiento = seguimientos[0];
+        const lastSeguimiento = await SeguimientoPaciente.findOne({ 'paciente.id': data.paciente.id }).sort({ createdAt: -1 });
+        if (lastSeguimiento) {
             const prestacion = {
                 idPrestacion: data._id,
                 tipoPrestacion: data.solicitud.tipoPrestacion.term,
@@ -88,9 +87,8 @@ EventCore.on('epidemiologia:prestaciones:validate', async (data) => {
 
 
 EventCore.on('epidemiologia:prestaciones:romperValidacion', async (data) => {
-    const seguimientos = await SeguimientoPaciente.find({ 'paciente.id': data.paciente.id }).sort({ createdAt: -1 });
-    if (seguimientos) {
-        const lastSeguimiento: any = seguimientos[0];
+    const lastSeguimiento: any = await SeguimientoPaciente.findOne({ 'paciente.id': data.paciente.id }).sort({ createdAt: -1 });
+    if (lastSeguimiento) {
         const indexPrestacion = lastSeguimiento.llamados.findIndex(field => field.idPrestacion.toString() === data._id.toString());
         if (indexPrestacion !== -1 || lastSeguimiento.ultimoEstado.idPrestacion.toString() === data._id.toString()) {
             if (indexPrestacion !== -1) {


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/EP-113

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Con el control anterior, si el array es vació entra al if, se modifica a findeOne para obtener el ultimo seguimiento y funcione correctamente el if.


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No

