### PR TITLE
SCRIPT: Actualizar turnos con Sumar

### DIFF
--- a/scripts/add-sumar-turnos.ts
+++ b/scripts/add-sumar-turnos.ts
@@ -1,0 +1,46 @@
+import { Agenda } from '../modules/turnos/schemas/agenda';
+import { sumar } from '../modules/obraSocial/schemas/sumar';
+import { Types } from 'mongoose';
+
+
+async function run(done) {
+    const ultimasAgendas = {
+        $and: [
+            { horaInicio: { $gte: new Date('2021-07-22T00:00:00.000-03:00') } },
+            { horaInicio: { $lte: new Date('2021-08-02T00:00:00.000-03:00') } }
+        ]
+    };
+    const agendas = Agenda.find(ultimasAgendas).cursor();
+    const obraSocial = {
+        codigoPuco: null,
+        nombre: 'SUMAR',
+        financiador: 'SUMAR',
+    };
+    for await (const agenda of agendas) {
+        for await (const bloque of agenda.bloques) {
+            for await (const turno of bloque.turnos) {
+                if (turno.estado === 'asignado') {
+                    if (!turno.paciente.obraSocial) {
+                        const pacienteSumar = await sumar.find({
+                            $and: [
+                                { activo: 'S ' }, { afidni: turno.paciente.documento }
+                            ]
+                        });
+                        if (pacienteSumar.length) {
+                            await Agenda.update(
+                                { _id: agenda.id },
+                                {
+                                    $set: { 'bloques.$[elemento1].turnos.$[elemento2].paciente.obraSocial': obraSocial }
+                                },
+                                { arrayFilters: [{ 'elemento1._id': Types.ObjectId(bloque.id) }, { 'elemento2._id': Types.ObjectId(turno.id) }] }
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    };
+    done();
+}
+
+export = run;

--- a/scripts/add-sumar-turnos.ts
+++ b/scripts/add-sumar-turnos.ts
@@ -8,10 +8,10 @@ async function run(done) {
         // Fechas entre las que hubo problema con pacientes SUMAR
         $and: [
             { horaInicio: { $gte: new Date('2021-07-15T00:00:00.000-03:00') } },
-            { horaInicio: { $lte: new Date('2021-08-02T00:00:00.000-03:00') } }
+            { horaInicio: { $lte: new Date('2021-08-04T00:00:00.000-03:00') } }
         ]
     };
-    const agendas = Agenda.find(ultimasAgendas).cursor();
+    const agendas = Agenda.find(ultimasAgendas).cursor({ batchSize: 100 });
     const obraSocial = {
         codigoPuco: null,
         nombre: 'SUMAR',

--- a/scripts/add-sumar-turnos.ts
+++ b/scripts/add-sumar-turnos.ts
@@ -5,8 +5,9 @@ import { Types } from 'mongoose';
 
 async function run(done) {
     const ultimasAgendas = {
+        // Fechas entre las que hubo problema con pacientes SUMAR
         $and: [
-            { horaInicio: { $gte: new Date('2021-07-22T00:00:00.000-03:00') } },
+            { horaInicio: { $gte: new Date('2021-07-15T00:00:00.000-03:00') } },
             { horaInicio: { $lte: new Date('2021-08-02T00:00:00.000-03:00') } }
         ]
     };

--- a/scripts/add-sumar-turnos.ts
+++ b/scripts/add-sumar-turnos.ts
@@ -36,6 +36,20 @@ async function run(done) {
                 }
             }
         }
+        for (const sobreturno of agenda.sobreturnos) {
+            if (!sobreturno.paciente.obraSocial) {
+                const pacienteSumar = await sumar.find({ activo: 'S ', afidni: sobreturno.paciente.documento });
+                if (pacienteSumar.length) {
+                    await Agenda.update(
+                        { _id: agenda.id },
+                        {
+                            $set: { 'sobreturnos.$[elemento].paciente.obraSocial': obraSocial }
+                        },
+                        { arrayFilters: [{ 'elemento._id': Types.ObjectId(sobreturno.id) }] }
+                    );
+                }
+            }
+        }
     };
     done();
 }


### PR DESCRIPTION
### Requerimiento
En la ultima actualización de SUMAR hubo un problema con el script y no se renombro la colección, quedo con el nombre sumarOld. Entre el rango de fechas (15/07 -  04/8) los pacientes que están en SUMAR aparecían sin obra social por lo que no se podían enviar a faccionario.

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se agrega Script que actualiza los registros en la coleccion agenda agregandole a los pacientes SUMAR la obra social.


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No