### PR TITLE
Epidemiología - Agregar el profesional que confirmo y el que hisopo en la ficha covid 19

### DIFF
--- a/modules/forms/forms-epidemiologia/forms-epidemiologia-schema.ts
+++ b/modules/forms/forms-epidemiologia/forms-epidemiologia-schema.ts
@@ -66,8 +66,14 @@ FormsEpidemiologiaSchema.pre('save', function (next) {
 
     const seccionClasificacion = ficha.secciones.find(s => s.name === 'Tipo de confirmación y Clasificación Final');
     const clasificacionfinal = seccionClasificacion?.fields.find(f => f.clasificacionfinal)?.clasificacionfinal;
-
+    const muestraPcr = seccionClasificacion?.fields.find(f => f.pcrM)?.pcrM;
+    const seccionUsuario = ficha.secciones.find(s => s.name === 'Usuario');
     if (clasificacionfinal === 'Confirmado') {
+        const usuarioConfirma = seccionClasificacion?.fields.find(f => f.usuarioconfirma)?.usuarioconfirma;
+        if (!usuarioConfirma) {
+            const user = seccionUsuario.fields.find(f => f.responsable)?.responsable;
+            seccionClasificacion.fields.push({ usuarioconfirma: user });
+        }
         const edadPaciente = calcularEdad(ficha.paciente.fechaNacimiento, ficha.createdAt);
         const comorbilidades = ficha.secciones.find(s => s.name === 'Enfermedades Previas')?.fields.find(f => f.presenta)?.presenta;
         ficha.score = {
@@ -75,6 +81,13 @@ FormsEpidemiologiaSchema.pre('save', function (next) {
             fecha: new Date()
         };
         EventCore.emitAsync('epidemiologia:seguimiento:create', ficha);
+    }
+    if (muestraPcr) {
+        const usuarioPcr = seccionClasificacion?.fields.find(f => f.usuarioconfirma)?.usuarioconfirma;
+        if (!usuarioPcr) {
+            const user = seccionUsuario.fields.find(f => f.responsable)?.responsable;
+            seccionClasificacion.fields.push({ usuariopcr: user });
+        }
     }
     next();
 });


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/EP-115

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. En el pre save del `FormsEpidemiologiaSchema` si la ficha viene como confirmada, se guarda el nombre completo del usuario que hizo esta confirmación y en el caso que se haya pedido un hisopado, se guarda también el usuario correspondiente.



### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No