### PR TITLE
fix(VAC): Corrige error de tipos en evento que elimina vacunas de nomivac

### DIFF
--- a/modules/vacunas/controller/vacunas.events.ts
+++ b/modules/vacunas/controller/vacunas.events.ts
@@ -47,7 +47,7 @@ export async function deleteVacunasFromNomivac(prestacion) {
         });
         const vacunaPrestacion = prestacion.ejecucion.registros[0].valor.vacuna;
         const vacuna = response.aplicacionesVacunasCiudadano?.aplicacionVacunaCiudadano?.find(
-            vac => vac.idSniVacuna === vacunaPrestacion.vacuna.codigo && vac.sniDosisOrden === vacunaPrestacion.dosis.orden
+            vac => vac.idSniVacuna === vacunaPrestacion.vacuna.codigo && parseInt(vac.sniDosisOrden, 10) === vacunaPrestacion.dosis.orden
         );
         if (vacuna) {
             const establecimiento = await Organizacion.findById(prestacion.ejecucion.organizacion.id);


### PR DESCRIPTION
### Requerimiento
Corregir bug en evento que elimina vacunas de nomivac

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Casteo de tipo en dosis de la vacuna que viene de nomivac para comparar con la dosis registrada en la prestación.


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No

