### PR TITLE
fix(Dashboards): Agrega al gráfico de tipos de turnos los que están sin clasificar

### DIFF
--- a/modules/turnos/controller/estadisticas.ts
+++ b/modules/turnos/controller/estadisticas.ts
@@ -132,16 +132,35 @@ const facets = {
     tipoTurno: [
         {
             $match: {
-                'turno.estado': 'asignado',
-                estado: { $ne: 'suspendida' },
-                'turno.tipoTurno': { $ne: null }
+                $or:[{'turno.estado':'asignado'},{'turno.estado':'disponible'}],
+                estado:{$ne:'suspendida'},
+            }
+        },
+        {
+            $addFields: {
+                tipo:{
+                    $cond:{
+                        if:{
+                            $ne: [
+                                {
+                                    $in: [
+                                        { $type: '$turno.tipoTurno' },
+                                        ['missing', 'null', 'undefined']
+                                    ]
+                                },
+                                true]
+                        },
+                        then:'$turno.tipoTurno',
+                        else:'Sin tipo'
+                    }
+                }
             }
         },
         {
             $group: {
-                _id: '$turno.tipoTurno',
+                _id: '$tipo',
                 count: { $sum: 1 },
-                nombre: { $first: '$turno.tipoTurno' }
+                nombre: { $first: '$tipo' }
             }
         },
         { $sort: { count: -1 } }


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/BI-94

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se modifica query para que tenga en cuenta los turnos que quedaron disponibles.

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No



<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
