### PR TITLE
fix(reporteC2): cambio en match de turnos y sobreturnos

### DIFF
--- a/modules/turnos/controller/diagnosticosC2Controller.ts
+++ b/modules/turnos/controller/diagnosticosC2Controller.ts
@@ -134,7 +134,12 @@ export function getDiagnosticos(params) {
                         $unwind: '$bloques.turnos'
                     },
                     {
-                        $match: matchAgedas
+                        $match: {
+                            'bloques.turnos.diagnostico.codificaciones.codificacionAuditoria.c2': true,
+                            'bloques.turnos.diagnostico.codificaciones.primeraVez': true,
+                            horaInicio: { $gte: new Date(params.horaInicio) },
+                            horaFin: { $lte: new Date(params.horaFin) },
+                        }
                     },
 
                     {
@@ -184,7 +189,12 @@ export function getDiagnosticos(params) {
                          $unwind: '$sobreturnos.diagnostico.codificaciones'
                      },
                      {
-                         $match: matchSobreturnos
+                         $match: {
+                             'sobreturnos.diagnostico.codificaciones.codificacionAuditoria.c2': true,
+                             'sobreturnos.diagnostico.codificaciones.primeraVez': true,
+                             horaInicio: { $gte: new Date(params.horaInicio) },
+                             horaFin: { $lte: new Date(params.horaFin) },
+                         }
                      },
                      {
                          $project: {


### PR DESCRIPTION

### Requerimiento
Los turnos y sobreturnos codificados no se visualizaban porque el match accedía a la posición 0 de un objeto

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. 
2. 
3. 


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
