### PR TITLE
MAT: filtrar matricula por fechas aisladas

### DIFF
--- a/core/tm/routes/profesional.ts
+++ b/core/tm/routes/profesional.ts
@@ -480,22 +480,44 @@ router.get('/profesionales/matriculas', Auth.authenticate(), async (req, res, ne
             profesionalMatriculado: 1
         };
     }
-    if (req.query.fechaDesde && req.query.fechaHasta) {
-        if (req.query.matriculasPorVencer) {
-            if (req.query.tipoMatricula === 'grado') {
-                match2['$and'] = [{ 'ultimaMatricula.fin': { $gte: new Date(req.query.fechaDesde) } },
-                                  { 'ultimaMatricula.fin': { $lte: new Date(req.query.fechaHasta) } }];
-            } else {
-                match2['$and'] = [{ 'ultimaMatriculaPosgrado.fin': { $gte: new Date(req.query.fechaDesde) } },
-                                  { 'ultimaMatriculaPosgrado.fin': { $lte: new Date(req.query.fechaHasta) } }];
+    if (req.query.matriculasPorVencer) {
+        if (req.query.tipoMatricula === 'grado') {
+            if (req.query.fechaDesde) {
+                if (req.query.fechaHasta) {
+                    match2['$and'] = [{ 'ultimaMatricula.fin': { $gte: new Date(req.query.fechaDesde) } },
+                                      { 'ultimaMatricula.fin': { $lte: new Date(req.query.fechaHasta) } }];
+                } else {
+                    match2['ultimaMatricula.fin'] = { $gte: new Date(req.query.fechaDesde) };
+                }
             }
-        } else if (req.query.matriculasPorVencer === false) {
-            if (req.query.tipoMatricula === 'grado') {
-                match2['$and'] = [{ 'ultimaMatricula.inicio': { $gte: new Date(req.query.fechaDesde) } },
-                                  { 'ultimaMatricula.inicio': { $lte: new Date(req.query.fechaHasta) } }];
-            } else {
-                match2['$and'] = [{ 'ultimaMatriculaPosgrado.inicio': { $gte: new Date(req.query.fechaDesde) } },
-                                  { 'ultimaMatriculaPosgrado.inicio': { $lte: new Date(req.query.fechaHasta) } }];
+        } else {
+            if (req.query.fechaDesde) {
+                if (req.query.fechaHasta) {
+                    match2['$and'] = [{ 'ultimaMatriculaPosgrado.fin': { $gte: new Date(req.query.fechaDesde) } },
+                                      { 'ultimaMatriculaPosgrado.fin': { $lte: new Date(req.query.fechaHasta) } }];
+                } else {
+                    match2['ultimaMatriculaPosgrado.fin'] = { $gte: new Date(req.query.fechaDesde) };
+                }
+            }
+        }
+    } else {
+        if (req.query.tipoMatricula === 'grado') {
+            if (req.query.fechaDesde) {
+                if (req.query.fechaHasta) {
+                    match2['$and'] = [{ 'ultimaMatricula.inicio': { $gte: new Date(req.query.fechaDesde) } },
+                                      { 'ultimaMatricula.inicio': { $lte: new Date(req.query.fechaHasta) } }];
+                } else {
+                    match2['ultimaMatricula.inicio'] = { $gte: new Date(req.query.fechaDesde) };
+                }
+            }
+        } else {
+            if (req.query.fechaDesde) {
+                if (req.query.fechaHasta) {
+                    match2['$and'] = [{ 'ultimaMatriculaPosgrado.inicio': { $gte: new Date(req.query.fechaDesde) } },
+                                      { 'ultimaMatriculaPosgrado.inicio': { $lte: new Date(req.query.fechaHasta) } }];
+                } else {
+                    match2['ultimaMatriculaPosgrado.inicio'] = { $gte: new Date(req.query.fechaDesde) };
+                }
             }
         }
     }


### PR DESCRIPTION
### Requerimiento
En reportes, permitir filtrar por fechaDesde y fechaHasta aisladas, no solo por rango completo.

### Funcionalidad desarrollada 
1. Se modifica la ruta /profesionales/matricula para buscar por fechaHasta y fechaDesde

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [X] No
