### PR TITLE
PER: sumar nota al schema de carnet perinatal

### DIFF
--- a/modules/perinatal/schemas/carnet-perinatal.schema.ts
+++ b/modules/perinatal/schemas/carnet-perinatal.schema.ts
@@ -42,6 +42,7 @@ export const CarnetPerinatalSchema = new Schema({
         fsn: String,
         semanticTag: String
     },
+    nota: String
 });
 
 CarnetPerinatalSchema.plugin(AuditPlugin);


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/PER-53

### Funcionalidad desarrollada 
1. Sumar nota al schema de carnet perinatal

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
