### PR TITLE
VAC: se evita que se sincronicen vacunas al cargar el concepto como registro

### DIFF
--- a/modules/vacunas/controller/inscripcion-vacunas.events.ts
+++ b/modules/vacunas/controller/inscripcion-vacunas.events.ts
@@ -2,7 +2,6 @@ import { EventCore } from '@andes/event-bus';
 import { InscripcionVacunasCtr } from '../inscripcion-vacunas.routes';
 import { userScheduler } from '../../../config.private';
 import { validarInscripcion } from './inscripcion.vacunas.controller';
-import { sincronizarVacunas, deleteVacunasFromNomivac } from './vacunas.events';
 
 const dataLog: any = new Object(userScheduler);
 dataLog.body = { _id: null };
@@ -23,7 +22,6 @@ EventCore.on('vacunas:inscripcion:vacunado', async ({ prestacion }) => {
         inscripto.idPrestacionVacuna = prestacion._id;
         await InscripcionVacunasCtr.update(inscripto.id, inscripto, dataLog);
     }
-    await sincronizarVacunas(prestacion.paciente.id);
 });
 
 // Quita la fecha de vacunacion si se rompe la validacion
@@ -33,16 +31,6 @@ EventCore.on('vacunas:inscripcion:cancelar-vacunado', async ({ prestacion }) => 
         inscripto.fechaVacunacion = null;
         inscripto.idPrestacionVacuna = null;
         await InscripcionVacunasCtr.update(inscripto.id, inscripto, dataLog);
-        await sincronizarVacunas(prestacion.paciente.id);
-
-        if (prestacion.estadoActual.tipo === 'ejecucion') {
-            const data = {
-                paciente: prestacion.paciente,
-                ejecucion : { registros: prestacion.ejecucion.registros.filter(reg => reg.concepto.conceptId === '840534001' )},
-                organizacion: prestacion.organizacion
-            };
-            await deleteVacunasFromNomivac(data);
-        }
     }
 
 });

--- a/modules/vacunas/controller/vacunas.events.ts
+++ b/modules/vacunas/controller/vacunas.events.ts
@@ -20,7 +20,7 @@ EventCore.on('mobile:patient:login', async (account) => {
 EventCore.on('rup:prestaciones:vacunacion', async (prestacion) => {
     if (!prestacion.paciente) {
         // Cuando se utiliza el concepto como registro y no prestación.
-        return;
+        prestacion = prestacion.prestacion;
     }
     await sincronizarVacunas(prestacion.paciente.id);
 
@@ -45,7 +45,12 @@ export async function deleteVacunasFromNomivac(prestacion) {
             documento: prestacion.paciente.documento,
             sexo: prestacion.paciente.sexo === 'masculino' ? 'M' : 'F'
         });
-        const vacunaPrestacion = prestacion.ejecucion.registros[0].valor.vacuna;
+        let vacunaPrestacion;
+        if (prestacion.ejecucion.registros[0].valor) {
+            vacunaPrestacion = prestacion.ejecucion.registros[0].valor.vacuna;
+        } else {
+            vacunaPrestacion = prestacion.ejecucion.registros[0].registros[0].valor.vacuna;
+        }
         const vacuna = response.aplicacionesVacunasCiudadano?.aplicacionVacunaCiudadano?.find(
             vac => vac.idSniVacuna === vacunaPrestacion.vacuna.codigo && parseInt(vac.sniDosisOrden, 10) === vacunaPrestacion.dosis.orden
         );


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/VAC-106

### Funcionalidad desarrollada 
1. Se vuelve para atrás el PR  https://github.com/andes/api/pull/1540 y se modifican los eventos de vacunas para que sincronicen y eliminen las vacunas de nomivac tanto en registros como en prestaciones.

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [X] No

Actualizar el elementoRup asociado al concepto 840534001 y sumar al dispatch:

        {
            "event" : "rup:prestaciones:vacunacion",
            "method" : "validar-prestacion"
        }, 
        {
            "event" : "rup:prestaciones:vacunacion",
            "method" : "romper-validacion"
        }

Para el elementoRup asociado al conceptId 1821000246103, eliminar esos eventos del dispatch.
