### PR TITLE
INT: censo diario - corrige visualizacion en días estada 

### DIFF
--- a/modules/rup/internacion/censo.controller.test.ts
+++ b/modules/rup/internacion/censo.controller.test.ts
@@ -228,6 +228,7 @@ test('Censo diario - Paciente desde 0hs tiene pase A', async () => {
     const cama2 = await store(seedCama(1, 'y', otraUnidadOrganizativa) as any, REQMock);
     const nuevaPrestacion: any = new Prestacion(createInternacionPrestacion(cama.organizacion));
     nuevaPrestacion.ejecucion.registros[0].valor.informeIngreso.fechaIngreso = moment().subtract(1, 'day').toDate();
+    nuevaPrestacion.ejecucion.registros[1].valor.InformeEgreso.fechaEgreso = null;
 
     Auth.audit(nuevaPrestacion, ({ user: {} }) as any);
     const internacion = await nuevaPrestacion.save();
@@ -245,27 +246,28 @@ test('Censo diario - Paciente desde 0hs tiene pase A', async () => {
         REQMock
     );
 
+    const extras = { unidadOrganizativaOrigen: cama.unidadOrganizativaOriginal };
     await CamasEstadosController.store(
         { organizacion, ambito, capa, cama: String(cama2._id) },
-        estadoOcupada(moment().subtract(1, 'm').toDate(), internacion._id, otraUnidadOrganizativa),
+        estadoOcupada(moment().subtract(1, 'm').toDate(), internacion._id, otraUnidadOrganizativa, extras),
         REQMock
     );
 
-    // const resultado = await CensoController.censoDiario({ organizacion, timestamp: moment().toDate(), unidadOrganizativa });
+    const resultado = await CensoController.censoDiario({ organizacion, timestamp: moment().toDate(), unidadOrganizativa });
 
-    // expect(resultado.censo).toEqual({
-    //     existenciaALas0: 1,
-    //     ingresos: 0,
-    //     pasesDe: 0,
-    //     altas: 0,
-    //     defunciones: 0,
-    //     pasesA: 1,
-    //     existenciaALas24: 0,
-    //     ingresosYEgresos: 0,
-    //     pacientesDia: 0,
-    //     disponibles: 1,
-    //     diasEstada: 2
-    // });
+    expect(resultado.censo).toEqual({
+        existenciaALas0: 1,
+        ingresos: 0,
+        pasesDe: 0,
+        altas: 0,
+        defunciones: 0,
+        pasesA: 1,
+        existenciaALas24: 0,
+        ingresosYEgresos: 0,
+        pacientesDia: 0,
+        disponibles: 1,
+        diasEstada: 1
+    });
 
     // const censoMan = await CensoController.censoDiario({ organizacion, timestamp: moment().add(1, 'd').toDate(), unidadOrganizativa });
     const censoManUO = await CensoController.censoDiario({ organizacion, timestamp: moment().add(1, 'd').toDate(), unidadOrganizativa: otraUnidadOrganizativa.conceptId });
@@ -294,7 +296,7 @@ test('Censo diario - Paciente desde 0hs tiene pase A', async () => {
         existenciaALas24: 1,
         ingresosYEgresos: 0,
         pacientesDia: 1,
-        diasEstada: 1,
+        diasEstada: 0,
         disponibles: 1
     });
 });
@@ -424,9 +426,10 @@ test('Censo diario - Paciente ingresa y tiene pase A', async () => {
     await CamasEstadosController.store({ organizacion, ambito, capa, cama: idCama },
         estadoDisponible(cama.unidadOrganizativaOriginal, 1, 'minute'), REQMock);
 
+    const extras = { unidadOrganizativaOrigen: cama.unidadOrganizativaOriginal };
     await CamasEstadosController.store(
         { organizacion, ambito, capa, cama: String(cama2._id) },
-        estadoOcupada(moment().subtract(1, 'm').toDate(), internacion._id, otraUnidadOrganizativa),
+        estadoOcupada(moment().subtract(1, 'm').toDate(), internacion._id, otraUnidadOrganizativa, extras),
         REQMock
     );
 
@@ -458,16 +461,16 @@ test('Censo diario - Paciente ingresa y tiene paseA y luego paseDe y se queda', 
         estadoOcupada(moment().subtract(4, 'm').toDate(), internacion._id, cama.unidadOrganizativaOriginal),
         REQMock
     );
-
+    let extras = { unidadOrganizativaOrigen: cama.unidadOrganizativaOriginal };
     await CamasEstadosController.store(
         { organizacion, ambito, capa, cama: idCama },
-        estadoOcupada(moment().subtract(2, 'm').toDate(), internacion._id, otraUnidadOrganizativa),
+        estadoOcupada(moment().subtract(2, 'm').toDate(), internacion._id, otraUnidadOrganizativa, extras),
         REQMock
     );
-
+    extras = { unidadOrganizativaOrigen: otraUnidadOrganizativa };
     await CamasEstadosController.store(
         { organizacion, ambito, capa, cama: idCama },
-        estadoOcupada(moment().subtract(1, 'm').toDate(), internacion._id, cama.unidadOrganizativaOriginal),
+        estadoOcupada(moment().subtract(1, 'm').toDate(), internacion._id, cama.unidadOrganizativaOriginal, extras),
         REQMock
     );
 
@@ -544,16 +547,16 @@ test('Censo diario - Paciente ingresa y tiene paseA y luego paseDe y tiene defun
         estadoOcupada(moment().subtract(4, 'm').toDate(), internacion._id, cama.unidadOrganizativaOriginal),
         REQMock
     );
-
+    let extras = { unidadOrganizativaOrigen: cama.unidadOrganizativaOriginal };
     await CamasEstadosController.store(
         { organizacion, ambito, capa, cama: idCama },
-        estadoOcupada(moment().subtract(2, 'm').toDate(), internacion._id, otraUnidadOrganizativa),
+        estadoOcupada(moment().subtract(2, 'm').toDate(), internacion._id, otraUnidadOrganizativa, extras),
         REQMock
     );
-
+    extras = { unidadOrganizativaOrigen: otraUnidadOrganizativa };
     await CamasEstadosController.store(
         { organizacion, ambito, capa, cama: idCama },
-        estadoOcupada(moment().subtract(1, 'm').toDate(), internacion._id, cama.unidadOrganizativaOriginal),
+        estadoOcupada(moment().subtract(1, 'm').toDate(), internacion._id, cama.unidadOrganizativaOriginal, extras),
         REQMock
     );
 
@@ -702,18 +705,20 @@ test('Censo diario - Paciente tiene paseDe y tiene paseA', async () => {
         REQMock
     );
 
+    let extras = { unidadOrganizativaOrigen: otraUnidadOrganizativa };
     await CamasEstadosController.store(
         { organizacion, ambito, capa, cama: idCama },
-        estadoOcupada(moment().subtract(2, 'm').toDate(), internacion._id, cama.unidadOrganizativaOriginal),
+        estadoOcupada(moment().subtract(2, 'm').toDate(), internacion._id, cama.unidadOrganizativaOriginal, extras),
         REQMock
     );
 
     await CamasEstadosController.store({ organizacion, ambito, capa, cama: idCama },
         estadoDisponible(cama.unidadOrganizativaOriginal, 1, 'minutes'), REQMock);
 
+    extras = { unidadOrganizativaOrigen: cama.unidadOrganizativaOriginal };
     await CamasEstadosController.store(
         { organizacion, ambito, capa, cama: cama2._id },
-        estadoOcupada(moment().subtract(1, 'm').toDate(), internacion._id, otraUnidadOrganizativa),
+        estadoOcupada(moment().subtract(1, 'm').toDate(), internacion._id, otraUnidadOrganizativa, extras),
         REQMock
     );
 

--- a/modules/rup/internacion/censo.controller.ts
+++ b/modules/rup/internacion/censo.controller.ts
@@ -88,6 +88,7 @@ async function realizarConteo(internaciones, unidadOrganizativa, timestampStart,
                     e.extras.unidadOrganizativaOrigen.conceptId !== unidadOrganizativa);
                 const movEgresaUO = estadosInter.filter(e => e.extras && e.extras.unidadOrganizativaOrigen &&
                     e.extras.unidadOrganizativaOrigen.conceptId === unidadOrganizativa);
+
                 let fechaIngresoUO = null;
                 if (movimientosUO.length) {
                     movimientosUO.sort((a, b) => (a.fecha - b.fecha));
@@ -104,8 +105,8 @@ async function realizarConteo(internaciones, unidadOrganizativa, timestampStart,
                     movEgresaUO.sort((a, b) => (b.fecha - a.fecha));
                     // si se egresa de la UO el mismo dia de consulta en el censo
                     esPaseA = moment(movEgresaUO[0].fecha).isSame(timestampEnd, 'day');
-
                 }
+
                 dataInternaciones[idInter]['allMovimientos'] = allMovimientos;
                 dataInternaciones[idInter]['ultimoMovimientoUO'] = ultimoMovimientoUO;
                 dataInternaciones[idInter]['fechaIngresoUO'] = fechaIngresoUO;
@@ -153,8 +154,9 @@ async function realizarConteo(internaciones, unidadOrganizativa, timestampStart,
                 };
             }
         }
+        const egresaDiaCenso = fechaEgreso && (moment(fechaEgreso).isSameOrBefore(timestampEnd.toDate()));
 
-        if (fechaIngresoUO && (fechaEgreso || esPaseA)) {
+        if (fechaIngresoUO && (egresaDiaCenso || esPaseA)) {
             diasEstadaUO = timestampEnd.diff(fechaIngresoUO, 'days');
             diasEstadaUO = (diasEstadaUO === 0) ? 1 : diasEstadaUO;
         }
@@ -177,7 +179,7 @@ async function realizarConteo(internaciones, unidadOrganizativa, timestampStart,
                 }
             }
             if (ultimaUO === String(unidadOrganizativa)) {
-                if (moment(fechaEgreso).isSameOrBefore(timestampEnd.toDate())) {
+                if (egresaDiaCenso) {
                     if (informesInternacion.egreso.tipoEgreso.id === 'Defunción') {
                         defunciones++;
                     } else {


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
<!-- URL de la User Story, referencia al issue (#1111) o breve descripcion del requerimiento -->
Censo diario: se corrige la visualizción de días estada en internacion, ya que se mostraba siempre una vez que se le cargaba un egreso a la internación.
Descripción del error: Los días estada solo deben mostrarse el dia de egreso o "pase a" otra UO. El problema está en que una vez que se egresa el paciente, los dias estada se visualizan en el censo diario de todos los días que dura la internación.

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. 
2. 
3. 


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
