### PR TITLE
Script: Elimina vacunas duplicadas

### DIFF
--- a/scripts/VAC-108.ts
+++ b/scripts/VAC-108.ts
@@ -1,21 +1,19 @@
+import { sincronizarVacunas } from '../modules/vacunas/controller/vacunas.events';
 import { VacunasPacientes } from '../modules/vacunas/schemas/vacunas-pacientes.schema';
 
 async function run(done) {
     const from = new Date('2021-02-01T00:00:00.000-03:00');
     const vacunasPacientes: any = VacunasPacientes.aggregate([
-        { $match: { 'aplicaciones.fechaAplicacion': { $gte: from }, cantDosis: 1 } },
-        { $group: { _id: '$paciente.id', count: { $sum: 1 }, id: { $last: '$_id' } } },
+        { $match: { 'aplicaciones.fechaAplicacion': { $gte: from } } },
+        { $group: { _id: '$paciente.id', count: { $sum: 1 } } },
         { $match: { _id: { $ne: null }, count: { $gt: 1 } } },
-        { $project: { _id: '$id' } }
+        { $project: { pacienteId: '$_id' } }
     ]).cursor({ batchSize: 100 });
 
-    const ids = [];
-    for await (const vac of vacunasPacientes) {
-        ids.push(vac._id);
+    for await (const pacienteId of vacunasPacientes) {
+        await VacunasPacientes.remove({ 'paciente.id': pacienteId._id });
+        await sincronizarVacunas(pacienteId._id);
     }
-
-    await VacunasPacientes.remove({ _id: { $in: ids } });
-
     done();
 }
 


### PR DESCRIPTION
### Requerimiento
Eliminar las vacunas duplicadas en pacientes-vacunas

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se agrupa por paciente los registros de vacunas de la coleccion pacientes vacunas y se verifica que sean mayor a 1 los registros, si este es el caso, se eliminan dichos registros y se llama a la funcion sincronizar vacunas para que se regeneren correctamente.


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde 

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No
