### PR TITLE
Epidemiología - Agregar dispatch al hallazgo Paciente Internado

### DIFF
--- a/modules/seguimiento-paciente/interfaces/seguimiento-paciente.interface.ts
+++ b/modules/seguimiento-paciente/interfaces/seguimiento-paciente.interface.ts
@@ -1,4 +1,7 @@
+import { Types } from 'mongoose';
+
 export interface ISeguimientoPaciente {
+    id?: Types.ObjectId | string;
     fechaInicio: Date;
     origen: {
         id: string;
@@ -51,4 +54,5 @@ export interface ISeguimientoPaciente {
         valor: Date;
     };
     contactosEstrechos: any[];
+    internacion?: boolean;
 }

--- a/modules/seguimiento-paciente/seguimiento-pacientes.events.ts
+++ b/modules/seguimiento-paciente/seguimiento-pacientes.events.ts
@@ -183,3 +183,25 @@ EventCore.on('mapa-camas:paciente:egreso', async (estado) => {
         }
     }
 });
+
+EventCore.on('rup:paciente:internadoValidacion', async (data) => {
+    try {
+        const lastSeguimiento: ISeguimientoPaciente = await SeguimientoPaciente.findOne({ 'paciente.id': data.prestacion.paciente.id });
+        if (lastSeguimiento) {
+            return await SeguimientoPacienteCtr.update(lastSeguimiento.id, { internacion: true }, dataLog);
+        }
+    } catch (error) {
+        return error;
+    }
+});
+
+EventCore.on('rup:paciente:internadoRomperValidacion', async (data) => {
+    try {
+        const lastSeguimiento: ISeguimientoPaciente = await SeguimientoPaciente.findOne({ 'paciente.id': data.prestacion.paciente.id });
+        if (lastSeguimiento?.internacion) {
+            return await SeguimientoPacienteCtr.update(lastSeguimiento.id, { internacion: false }, dataLog);
+        }
+    } catch (error) {
+        return error;
+    }
+});

--- a/modules/vacunas/controller/vacunas.controller.ts
+++ b/modules/vacunas/controller/vacunas.controller.ts
@@ -76,8 +76,8 @@ export async function exportCovid19(horas, pacienteId?, desde?, hasta?) {
         },
         { $unwind: '$organizacion' }
     ];
-    const prestaciones = await Prestacion.aggregate(pipelineVacunaCovid19);
-    for (const unaPrestacion of prestaciones) {
+    const prestaciones: any = Prestacion.aggregate(pipelineVacunaCovid19).cursor({ batchSize: 100 });
+    for await (const unaPrestacion of prestaciones) {
         const prestacionRegistrada = await InformacionExportada.findOne({ 'resultado.resultado': 'OK', idPrestacion: unaPrestacion._id });
         if (!prestacionRegistrada) {
             const prestacionAux: any = new Prestacion(unaPrestacion);


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/EP-182

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se agregan dos eventos en seguimiento para que al validar/romper una prestacion con el hallazgo Paciente Internado(266938001), se refleje en seguimiento en el caso de que el paciente tenga uno activo.


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [x] Si Agregar el elemento rup
- [ ] No


[ElementoRup.txt](https://github.com/andes/api/files/7959029/ElementoRup.txt)

