### PR TITLE
Profesional - Param email

### DIFF
--- a/core/tm/routes/profesional.ts
+++ b/core/tm/routes/profesional.ts
@@ -183,6 +183,9 @@ router.get('/profesionales/guia', async (req, res, next) => {
     if (req.query.nombre) {
         opciones['nombre'] = makePattern(req.query.nombre);
     }
+    if (req.query.email) {
+        opciones['contactos.valor'] = req.query.email;
+    }
 
     if (opciones['formacionGrado.profesion.codigo'] && Object.keys(opciones).length === 1) {
         return next('Parámetros incorrectos');


### PR DESCRIPTION
### Requerimiento
Permitir busqueda por email para corroborar informacion de nuevos usuarios para recetAR

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se agrega la posibilidad de enviar al get de la guiá de profesionales, el email como param para verificar que el ingresado en el nuevo formulario de usuarios de recetAR sea el mismo que el registrado en la base de Andes.



### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No
