### PR TITLE
Cantidad de embarazos

### DIFF
--- a/modules/perinatal/schemas/carnet-perinatal.schema.ts
+++ b/modules/perinatal/schemas/carnet-perinatal.schema.ts
@@ -42,6 +42,7 @@ export const CarnetPerinatalSchema = new Schema({
         fsn: String,
         semanticTag: String
     },
+    cantidadEmbarazos: Number,
     nota: String
 });
 


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
https://proyectos.andes.gob.ar/browse/PER-77

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se modifico el esquema de carnet-perinatal para poder agregar la cantidad de embarazos en caso de que se seleccione el term "mas de 10 embarazos".

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [X] Si
- [ ] No

En la colección elementos rup con este id: ObjectId("5b057eaf623ded31ac70ed94") se agrego dentro de params un booleano
"required:true" para que sea obligatorio el campo de ingresar el numero de embarazos en caso de seleccionar la opción del select "mas de 10 embarazos". Tambien se elimino la variable max que tiene la cantidad maxima de embarazos ya que se lo considera innecesario a la hora de escribir el numero y se modifico la variable min dejandola en 1.

<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
