### PR TITLE
Plan Indicaciones - Modificar grilla horaria del plan

### DIFF
--- a/modules/rup/internacion/plan-indicaciones/plan-indicaciones.routes.ts
+++ b/modules/rup/internacion/plan-indicaciones/plan-indicaciones.routes.ts
@@ -3,6 +3,7 @@ import { MongoQuery, ResourceBase, ResourceNotFound } from '@andes/core';
 import { Auth } from '../../../../auth/auth.class';
 import { IPlanIndicacionesDoc, PlanIndicaciones } from './plan-indicaciones.schema';
 import { EventCore } from '@andes/event-bus/';
+import * as moment from 'moment';
 class PlanIndicacionesController extends ResourceBase<IPlanIndicacionesDoc> {
     Model = PlanIndicaciones;
     resourceName = 'plan-indicaciones';
@@ -17,7 +18,13 @@ class PlanIndicacionesController extends ResourceBase<IPlanIndicacionesDoc> {
         fechaBaja: MongoQuery.matchDate,
         internacion: MongoQuery.equalMatch.withField('idInternacion'),
         prestacion: MongoQuery.equalMatch.withField('idPrestacion'),
-        registro: MongoQuery.equalMatch.withField('idRegistro')
+        registro: MongoQuery.equalMatch.withField('idRegistro'),
+        rangoFechas:(fecha: Date)=>{
+            return { $or:[
+                { fechaInicio: { $gte: moment(fecha).startOf('day').toDate() } },
+                { fechaInicio: { $lte: moment(fecha).endOf('day').add(1, 'd').toDate() } }
+            ] };
+        }
     };
     eventBus = EventCore;
 }


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/IN-471

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se agrega la posibilidad de obtener el horario de inicio del plan de indicaciones dada una organización.
2. Se agrega posibilidad de filtrar por el rango de fechas en el plan de indicaciones.
3. 


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [x] Si
- [ ] No

En cada organización que quiera usar el plan, agregar en el objeto configuraciones , un objeto plan de indicaciones con un campo llamado horaInicio con un horario ej:
```
"configuraciones" :{
    "planIndicaciones" : {
        "horaInicio" : 6
    }
}
```
Quedan configurados en la base de demo el castro rendon y el hospital de centenario.
