### PR TITLE
fix(PACS): modifica Dicom Accession Number

### DIFF
--- a/modules/pacs/dicom/dicom.helpers.ts
+++ b/modules/pacs/dicom/dicom.helpers.ts
@@ -2,7 +2,8 @@ import * as moment from 'moment';
 import { IPrestacion } from '../../rup/prestaciones.interface';
 import { IPacsConfig } from '../pacs-config.schema';
 import { IDicomPatientData, DICOM_SHORT_STRING_MAX_LENGTH, DICOM_LONG_STRING_MAX_LENGTH, IDicomPrestacionData, IDicomInformeData } from './dicom.interfaces';
-import { constant } from 'async';
+
+const objectIdToBase64 = (id: string) => Buffer.from(id, 'hex').toString('base64url' as BufferEncoding);
 
 export const toISOIR100 = (text: string) => {
     const buffer = require('buffer');
@@ -56,7 +57,8 @@ export const mapDicomGender = (sexo?: string) => sexo === 'masculino' ? 'M' : 'F
 export function DICOMPaciente(config: IPacsConfig, paciente: any): IDicomPatientData {
     const pacienteId = String(paciente.id);
     const pacienteIDtrimmed = normalizeShortString(pacienteId, true, 15);
-    const pacienteIdDicom = (config.featureFlags?.usoIdDNI)
+    const usoIdDNI = config.featureFlags?.usoIdDNI;
+    const pacienteIdDicom = usoIdDNI
         ? (paciente.documento || pacienteIDtrimmed)
         : pacienteId;
     const id = pacienteIdDicom;
@@ -65,10 +67,18 @@ export function DICOMPaciente(config: IPacsConfig, paciente: any): IDicomPatient
     const fechaNacimiento = formatDicomDate(paciente.fechaNacimiento);
     const sexo = mapDicomGender(paciente.sexo);
 
+    // Other Patient ID: cuando hay documento, el campo alternativo es el otro
+    // identificador (sufijo ObjectId si el principal es el DNI, o el DNI si el
+    // principal es el ObjectId completo).
+    const otherPatientId = documento
+        ? (usoIdDNI ? pacienteIDtrimmed : documento)
+        : undefined;
+
     return {
         id,
         pacienteIDtrimmed,
         documento,
+        otherPatientId,
         fechaNacimiento,
         sexo,
         dicomName
@@ -85,7 +95,7 @@ export function DICOMPrestacion(prestacion: IPrestacion, pacienteIdDicom: string
     const scheduledDate = formatDicomDate(prestacion.ejecucion.fecha);
     const scheduledTime = formatDicomTime(prestacion.ejecucion.fecha);
     const uniqueID = `${config.ui}.${Date.now()}`;
-    const accessionNumber = `${Date.now()}`;
+    const accessionNumber = objectIdToBase64(String(prestacion.id));
     const procedureCode = normalizeShortString(prestacion.solicitud.tipoPrestacion.conceptId);
     const procedureDescription = toISOIR100(normalizeShortString(prestacion.solicitud.tipoPrestacion.term));
 
@@ -106,9 +116,9 @@ export function DICOMPrestacion(prestacion: IPrestacion, pacienteIdDicom: string
 
 export function DICOMInforme(prestacion: IPrestacion, paciente: IDicomPatientData): IDicomInformeData {
     const uid = prestacion.metadata.find(item => item.key === 'pacs-uid')?.valor as string;
+    const accessionNumber = prestacion.metadata.find(item => item.key === 'pacs-accessionNumber')?.valor as string;
     const profesional = prestacion.solicitud.profesionalOrigen || prestacion.solicitud.profesional;
-    const profesionalName = `${profesional.apellido}, ${profesional.nombre}`;
-    const orderCode = toISOIR100(prestacion.solicitud.tipoPrestacion.conceptId);
+    const profesionalName = buildDicomName(profesional.apellido, profesional.nombre);
     const studyDate = formatDicomDate(prestacion.ejecucion.fecha);
     const studyTime = formatDicomTime(prestacion.ejecucion.fecha);
     const instanceCreationDate = formatDicomDate(new Date());
@@ -121,7 +131,7 @@ export function DICOMInforme(prestacion: IPrestacion, paciente: IDicomPatientDat
         pacienteID: paciente.id,
         patientName: paciente.dicomName,
         profesionalName,
-        orderCode,
+        accessionNumber,
         studyDate,
         studyTime,
         instanceCreationDate,

--- a/modules/pacs/dicom/dicom.interfaces.ts
+++ b/modules/pacs/dicom/dicom.interfaces.ts
@@ -6,6 +6,7 @@ export interface IDicomPatientData {
     pacienteIDtrimmed: string;
     dicomName: string;
     documento?: string;
+    otherPatientId?: string;
     fechaNacimiento?: string;
     sexo?: string;
 }
@@ -31,7 +32,7 @@ export interface IDicomInformeData {
     pacienteID: string;
     patientName: string;
     profesionalName: string;
-    orderCode: string;
+    accessionNumber: string;
     studyDate: string;
     studyTime: string;
     instanceCreationDate: string;

--- a/modules/pacs/dicom/informe-encode.ts
+++ b/modules/pacs/dicom/informe-encode.ts
@@ -52,7 +52,7 @@ export function DICOMInformePDFObject(data: IDicomInformeData) {
         '00080050': {
             vr: 'SH',
             Value: [
-                data.orderCode
+                data.accessionNumber
             ],
         },
         '00080060': {

--- a/modules/pacs/dicom/paciente-encode.ts
+++ b/modules/pacs/dicom/paciente-encode.ts
@@ -34,7 +34,7 @@ export function DICOMPacienteObject(paciente: IDicomPatientData) {
         }
     };
 
-    if (paciente.documento) {
+    if (paciente.otherPatientId) {
         json['00101002'] = {
             vr: 'SQ',
             Value: [
@@ -42,7 +42,7 @@ export function DICOMPacienteObject(paciente: IDicomPatientData) {
                     '00100020': {
                         vr: 'LO',
                         Value: [
-                            paciente.pacienteIDtrimmed
+                            paciente.otherPatientId
                         ]
                     }
                 }


### PR DESCRIPTION
### Requerimiento

Corrección de inconsistencias en la generación de datos DICOM para integración PACS, y unificación del criterio de identificación de pacientes entre PACS y HL7v2.

### Funcionalidad desarrollada

1. **Accession Number determinista:** reemplaza `Date.now()` por `base64url(ObjectId de la prestación)` — mismo accession para la misma prestación, cabe exactamente en VR SH (16 chars), reversible.

2. **Other Patient ID (`00101002`) corregido:** cuando el paciente tiene documento, el ID alternativo es siempre el "otro" identificador — DNI si `usoIdDNI=false`, sufijo del ObjectId si `usoIdDNI=true`. Antes siempre se enviaba el sufijo del ObjectId independientemente del flag.

3. **ID sintético para pacientes sin DNI:** cuando `usoIdDNI=true` y el paciente no tiene documento, se genera un ID con el mismo patrón que HL7v2: `E{numeroIdentificacion}` o sufijo del ObjectId, más sexo y primeras 5 letras del apellido. Cabe en hl7v2(15 chars). El sufijo completo del ObjectId queda en `otherPatientId` (`00101002`) para reconciliación.

4. **Guardado del identificador PACS en el paciente:** al sincronizar el worklist, se persiste el ID PACS generado en `paciente.identificadores` con entidad `ANDESPACS`, siguiendo el mismo patrón que HL7v2. Permite lookup cruzado y auditoría del ID asignado.

5. **Informe PDF linkea por Accession Number con el worklist:** `00080050` en el informe ahora usa el valor guardado en metadata (`pacs-accessionNumber`) en lugar del conceptId del tipo de prestación, permitiendo correlación correcta entre worklist y estudio.

6. **Nombre del profesional en informe en formato DICOM estándar:** `DICOMInforme` usa `buildDicomName` (`APELLIDO^NOMBRE`) consistente con el worklist. Antes usaba `apellido, nombre` con coma.

7. **fix(HL7v2): normalización de entidad en comparación de identificadores:** se agrega `normalizeIdentifierEntity` para ignorar espacios en blanco al buscar identificadores existentes en `paciente.identificadores`, evitando duplicados por diferencias de formato (absorbe el PR #2229).

### UserStories llegó a completarse
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No
