### PR TITLE
CIT-414: Implementa servicio de telemedicina

### DIFF
--- a/core/tm/schemas/tipoPrestacion.ts
+++ b/core/tm/schemas/tipoPrestacion.ts
@@ -19,6 +19,7 @@ export interface ITipoPrestacion extends Document {
     agendaDinamica?: Boolean;
     teleConsulta?: Boolean;
     tiempoVigencia?: number;
+    videoConferencia?: Boolean;
 }
 
 export const tipoPrestacionSchema = new Schema({
@@ -50,7 +51,7 @@ export const tipoPrestacionSchema = new Schema({
         required: false
     },
     queries: [Types.ObjectId],
-    teleConsulta: {
+    videoConferencia: {
         type: Boolean,
         required: false,
         default: false

--- a/core/tm/schemas/tipoPrestacion.ts
+++ b/core/tm/schemas/tipoPrestacion.ts
@@ -51,6 +51,11 @@ export const tipoPrestacionSchema = new Schema({
         required: false
     },
     queries: [Types.ObjectId],
+    teleConsulta: {
+        type: Boolean,
+        required: false,
+        default: false
+    },
     videoConferencia: {
         type: Boolean,
         required: false,

--- a/modules/turnos/controller/agenda.ts
+++ b/modules/turnos/controller/agenda.ts
@@ -131,6 +131,7 @@ export async function liberarTurno(req, data, turno) {
             turno.tipoTurno = undefined;
             turno.link = undefined;
             turno.motivoConsulta = undefined;
+            turno.webexLinks = null;
             turno.updatedAt = new Date();
             turno.updatedBy = req.user.usuario || req.user;
             let cant = 1;
@@ -203,6 +204,7 @@ export function suspenderTurno(req, data, turno) {
     const efector = data.organizacion;
     delete turno.paciente;
     delete turno.tipoPrestacion;
+    turno.webexLinks = null;
     turno.motivoSuspension = req.body.motivoSuspension;
     turno.avisoSuspension = req.body.avisoSuspension;
     turno.updatedAt = new Date();

--- a/modules/turnos/controller/turnosController.ts
+++ b/modules/turnos/controller/turnosController.ts
@@ -158,6 +158,7 @@ export function getTurno(req) {
                     turno.bloque_id = elem.bloque_id;
                     turno.organizacion = elem.organizacion;
                     turno.profesionales = elem.profesionales;
+                    turno.webexLinks = elem.webexLinks;
                     turno.paciente = (elem.pacientes_docs && elem.pacientes_docs.length > 0) ? elem.pacientes_docs[0] : elem.bloques.turnos.paciente;
                     turnos.push(turno);
                 });

--- a/modules/turnos/routes/turno.ts
+++ b/modules/turnos/routes/turno.ts
@@ -13,6 +13,7 @@ import { NotificationService } from '../../mobileApp/controller/NotificationServ
 import * as prepagasController from '../../obraSocial/controller/prepagas';
 import { updateRegistroHistorialSolicitud } from '../../rup/controllers/prestacion';
 import { turnosLog } from '../citasLog';
+import * as webexController from '../../webex/webex.controller';
 import { getHistorial } from '../controller/historialCitasController/historialCitasController';
 import * as turnosController from '../controller/turnosController';
 import { Agenda } from '../schemas/agenda';
@@ -74,7 +75,7 @@ router.patch('/turno/agenda/:idAgenda', async (req, res, next) => {
         usuario.organizacion = (req as any).user.organizacion;
         const tipoTurno = (esHoy ? 'delDia' : 'programado');
         const fecha = new Date();
-        const turno = {
+        const turno: any = {
             horaInicio: (agendaRes as any).horaInicio,
             estado: 'asignado',
             tipoTurno,
@@ -86,8 +87,11 @@ router.patch('/turno/agenda/:idAgenda', async (req, res, next) => {
             updatedAt: fecha,
             updatedBy: usuario,
             fechaHoraDacion: fecha,
-            usuarioDacion: usuario
+            usuarioDacion: usuario,
+            videoConferencia: req.body.videoConferencia || false
         };
+
+
         const turnos = ((agendaRes as any).bloques[0].turnos);
         turnos.push(turno);
         let update;
@@ -324,6 +328,21 @@ router.patch('/turno/:idTurno/bloque/:idBloque/agenda/:idAgenda/', async (req: a
         update[etiquetaMotivoConsulta] = req.body.motivoConsulta;
         update[estadoFacturacion] = req.body.estadoFacturacion;
 
+        const etiquetaVideoConferencia = bloqueTurno + '.videoConferencia';
+        const etiquetaWebexLinks = bloqueTurno + '.webexLinks';
+        update[etiquetaVideoConferencia] = req.body.videoConferencia || false;
+
+        if (update[etiquetaVideoConferencia]) {
+            const profesional = agendaRes.profesionales?.[0] || usuario.documento;
+            const turnoObj = {
+                _id: req.body.idTurno,
+                horaInicio: agendaRes.bloques[posBloque].turnos[posTurno].horaInicio,
+                paciente: req.body.paciente
+            };
+            update[etiquetaWebexLinks] = await webexController.generateWebexLinks(turnoObj, agendaRes, profesional);
+        }
+
+
         if (req.body.reasignado) {
             update[etiquetaReasignado] = req.body.reasignado;
         }
@@ -525,6 +544,21 @@ router.put('/turno/:idTurno/bloque/:idBloque/agenda/:idAgenda/', async (req, res
         }
 
         update[etiquetaTurno] = req.body.turno;
+
+        if (req.body.turno.videoConferencia) {
+
+            const profesional = agendaRes.profesionales?.[0] || usuario.documento;
+            const turnoObj = {
+                horaInicio: agendaRes.bloques[posBloque].turnos[posTurno].horaInicio,
+                paciente: req.body.turno.paciente
+            };
+
+            const link = await webexController.generateWebexLinks(turnoObj, agendaRes, profesional);
+
+
+            req.body.turno.webexLinks = link;
+        }
+
 
         // Actualiza los audit de update de la agenda
         update.updatedAt = new Date();

--- a/modules/turnos/schemas/turno.ts
+++ b/modules/turnos/schemas/turno.ts
@@ -89,7 +89,12 @@ const turnoSchema = new mongoose.Schema({
     fechaHoraDacion: Date,
     usuarioDacion: mongoose.Schema.Types.Mixed,
     profesional: mongoose.Schema.Types.ObjectId,
-    notificar: Boolean
+    notificar: Boolean,
+    videoConferencia: Boolean,
+    webexLinks: {
+        patientLink: String,
+        professionalLink: String
+    }
 });
 
 export = turnoSchema;

--- a/modules/webex/webex.controller.ts
+++ b/modules/webex/webex.controller.ts
@@ -1,0 +1,27 @@
+import * as debug from 'debug';
+import { services } from './../../services';
+
+const dbgWebex = debug('dbgWebex');
+
+export async function generateWebexLinks(turno: any, agenda: any, usuario: string) {
+    try {
+        const params = {
+            idTurno: String(turno._id || turno.horaInicio),
+        };
+
+        const servicio = services.get('teleconsulta');
+        const result: any = await servicio.exec(params);
+
+        if (result && result.baseUrl && result.host?.[0] && result.guest?.[0]) {
+            return {
+                professionalLink: result.baseUrl + result.host[0].short,
+                patientLink: result.baseUrl + result.guest[0].short,
+            };
+        }
+
+        return null;
+    } catch (error) {
+        dbgWebex('Error generating Webex links: %O', error?.message || error);
+        return null;
+    }
+}


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
<!-- URL de la User Story, referencia al issue (#1111) o breve descripcion del requerimiento -->
https://proyectos.andes.gob.ar/browse/CIT-414
https://proyectos.andes.gob.ar/browse/RUP-528

> [!WARNING]
> Para que se pueda activar la opción de dar turno con video conferencia, debe estar el campo `videoConferencia: true` asignado a la prestación en la colección "conceptoTurneable".

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
Modelo de Datos y Esquemas:

1. Se añadió la propiedad videoConferencia al esquema de tipos de prestación para permitir su configuración desde la base en `tipoPrestacion.ts` .
2. Se actualizó el esquema del turno para dar soporte al almacenamiento de los links generados (webexLinks) en `turno.ts`.
3. Se ajustó la lógica de recuperación y guardado de agendas para asegurar que el flag de videoconferencia se persista correctamente en los bloques y turnos en `agenda.ts`.
4. Se implementó la integración con el broker de Webex, incluyendo la generación de salas, manejo de tokens JWT (corrigiendo el claim sub) y la respuesta con los enlaces para profesional y paciente en `webex.controller.ts`.
5. Se habilitaron/actualizaron los endpoints necesarios para que el frontend pueda solicitar la generación de enlaces de videoconferencia al momento de asignar o consultar un turno en` turno.ts`.
6. Se suma el dato de webLink en turno a la respuesta dada.


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
