### PR TITLE
CIT - Liberación de turnos simultáneos genera turno del día

### DIFF
--- a/modules/turnos/controller/agenda.ts
+++ b/modules/turnos/controller/agenda.ts
@@ -143,17 +143,23 @@ export async function liberarTurno(req, data, turno) {
                 autocitados: data.bloques[position.indexBloque].turnos.filter(t => t.estado === 'asignado' && t.tipoTurno === 'profesional').length || 0,
                 gestion: data.bloques[position.indexBloque].turnos.filter(t => t.estado === 'asignado' && t.tipoTurno === 'gestion').length || 0
             };
+            const bloque = data.bloques[position.indexBloque];
+            const cuposMaximos = {
+                gestion: getBloqueCupoMaximo(bloque, 'reservadoGestion'),
+                profesional: getBloqueCupoMaximo(bloque, 'reservadoProfesional'),
+                programado: getBloqueCupoMaximo(bloque, 'accesoDirectoProgramado')
+            };
 
-            if (data.bloques[position.indexBloque].restantesGestion < (data.bloques[position.indexBloque].reservadoGestion - turnosAsignados.gestion)) {
-                data.bloques[position.indexBloque].restantesGestion = data.bloques[position.indexBloque].restantesGestion + cant;
+            if (bloque.restantesGestion < (cuposMaximos.gestion - turnosAsignados.gestion)) {
+                bloque.restantesGestion = bloque.restantesGestion + cant;
             } else {
-                if (data.bloques[position.indexBloque].restantesProfesional < (data.bloques[position.indexBloque].reservadoProfesional - turnosAsignados.autocitados)) {
-                    data.bloques[position.indexBloque].restantesProfesional = data.bloques[position.indexBloque].restantesProfesional + cant;
+                if (bloque.restantesProfesional < (cuposMaximos.profesional - turnosAsignados.autocitados)) {
+                    bloque.restantesProfesional = bloque.restantesProfesional + cant;
                 } else {
-                    if (data.bloques[position.indexBloque].restantesProgramados < (data.bloques[position.indexBloque].accesoDirectoProgramado - turnosAsignados.programados)) {
-                        data.bloques[position.indexBloque].restantesProgramados = data.bloques[position.indexBloque].restantesProgramados + cant;
+                    if (bloque.restantesProgramados < (cuposMaximos.programado - turnosAsignados.programados)) {
+                        bloque.restantesProgramados = bloque.restantesProgramados + cant;
                     } else {
-                        data.bloques[position.indexBloque].restantesDelDia = data.bloques[position.indexBloque].restantesDelDia + cant;
+                        bloque.restantesDelDia = bloque.restantesDelDia + cant;
                     }
                 }
             }
@@ -174,6 +180,11 @@ export async function liberarTurno(req, data, turno) {
         }
     }
     return true;
+}
+
+function getBloqueCupoMaximo(bloque, campo) {
+    const multiplicador = bloque.pacienteSimultaneos ? (bloque.cantidadSimultaneos || 1) : 1;
+    return (bloque[campo] || 0) * multiplicador;
 }
 
 


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
https://proyectos.andes.gob.ar/browse/CIT-417

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se agrega una nueva funcionalidad que permite saber cuantos turnos simultáneos tiene un turno en particular para que haga la incrementación por el turno que le corresponde. 


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [X] No

Pasos para reproducir el error:
1. Creamos una agenda que tenga, por ejemplo, 1 turno (del ida, con llave, etc) y luego en box de pacientes simultáneos poner la cantidad que queramos. Entonces esto hace que solamente tengamos un turno pero con X cantidad de personas. 
2. Lo que venia sucediendo era que al momento de decrementar un turno (ya sea por asignación o por suspensión) y volvíamos a "cambiar a disponible" dicho turno, por descarte se terminaba siempre incrementando los turnos del día y no los que correspondían. 