### PR TITLE
REC - Mejoras en rutas de recetas med/insumos ANDES

### DIFF
--- a/modules/recetas/recetasController.ts
+++ b/modules/recetas/recetasController.ts
@@ -136,14 +136,15 @@ export async function buscarRecetas(req) {
     const sexo = params.sexo || null;
     const user = req.user;
     try {
-        if ((!pacienteId && (!documento || !sexo)) || (pacienteId && !Types.ObjectId.isValid(pacienteId))) {
+        if (!params.id && !params.idRegistro && ((!pacienteId && (!documento || !sexo)) || (pacienteId && !Types.ObjectId.isValid(pacienteId)))) {
             throw new ParamsIncorrect();
         }
         const paramMap = {
             id: '_id',
             pacienteId: 'paciente.id',
             documento: 'paciente.documento',
-            sexo: 'paciente.sexo'
+            sexo: 'paciente.sexo',
+            idRegistro: 'idRegistro'
         };
         Object.keys(paramMap).forEach(key => {
             if (params[key]) {
@@ -157,8 +158,6 @@ export async function buscarRecetas(req) {
         if (params.estadoDispensa) {
             const estadoDispensaArray = params.estadoDispensa.replace(/ /g, '').split(',');
             options['estadoDispensaActual.tipo'] = { $in: estadoDispensaArray };
-        } else {
-            options['estadoActual.tipo'] = null;
         }
         const estadoArray = params.estado ? params.estado.replace(/ /g, '').split(',') : [];
         const fechaFin = params.fechaFin ? moment(params.fechaFin).endOf('day').toDate() : moment().endOf('day').toDate();
@@ -312,7 +311,31 @@ export async function buscarRecetasConFiltros(req) {
             filter['paciente.sexo'] = sexo;
         }
 
-        const recetas = await Receta.find(filter);
+        let recetas: any = await Receta.find(filter);
+
+        if (!recetas.length) {
+            return [];
+        }
+
+        // Generar idAndes para recetas que no lo tengan
+        const recetasActualizadas = [];
+        for (const receta of recetas) {
+            if (!receta.idReceta) {
+                receta.idReceta = generarIdDesdeFecha(receta.createdAt || new Date());
+                Auth.audit(receta, req);
+                await receta.save();
+            }
+            recetasActualizadas.push(receta);
+        }
+        recetas = recetasActualizadas;
+
+        const user = req.user;
+        if (user?.type === 'app-token') {
+            // si es un usuario de app y no tiene nombre de sistema asignado, no se envia recetas
+            const sistema = user.app?.nombre ? user.app.nombre.toLowerCase() : '';
+            recetas = sistema ? await registrarAppNotificadas(req, recetas, sistema) : [];
+        }
+
         return recetas;
     } catch (err) {
         await informarLog.error('buscarRecetasConFiltros', { query: req.query }, err, req);
@@ -334,8 +357,8 @@ export async function suspender(recetaId, req) {
 
 
         if (recetasASuspender.length) {
-            const recetasSuspender = recetasASuspender.filter((r: any) => (r.estadoActual.tipo === 'vigente') || (r.estadoDispensaActual.tipo === 'dispensa-parcial' && r.estadoActual.tipo === 'pendiente'));
-            const recetasEliminar = recetasASuspender.filter((r: any) => (r.estadoDispensaActual.tipo === 'sin-dispensa' && r.estadoActual.tipo === 'pendiente'));
+            const recetasSuspender = recetasASuspender.filter((r: any) => (r.estadoActual.tipo === 'vigente') || (r.estadoDispensaActual?.tipo === 'dispensa-parcial' && r.estadoActual.tipo === 'pendiente'));
+            const recetasEliminar = recetasASuspender.filter((r: any) => (!r.estadoDispensaActual || r.estadoDispensaActual?.tipo === 'sin-dispensa') && r.estadoActual.tipo === 'pendiente');
             if (recetasSuspender.length === 0 && recetasEliminar.length !== 0) {
                 // en el tratamiento prolongado, al menos una receta debe quedar en estado suspendido
                 const recetaSusp = recetasEliminar.pop();

--- a/modules/recetas/recetasInsumos/receta-insumo.routes.ts
+++ b/modules/recetas/recetasInsumos/receta-insumo.routes.ts
@@ -2,12 +2,13 @@ import { MongoQuery, ResourceBase } from '@andes/core';
 import { Auth } from '../../../auth/auth.class';
 import { RecetaInsumo } from './receta-insumo.schema';
 import { asyncHandler, Request, Response } from '@andes/api-tool';
-import { create, buscarRecetasInsumos } from './recetaInsumosController';
+import { create, buscarRecetasInsumos, buscarRecetasInsumosConFiltros, setEstadoDispensa, actualizarAppNotificada, cancelarDispensa, suspender } from './recetaInsumosController';
+import { ParamsIncorrect } from '../recetas.error';
 
 class RecetaInsumoResource extends ResourceBase {
     Model = RecetaInsumo;
     resourceName = 'recetaInsumos';
-    routesEnable = ['get, post'];
+    routesEnable = ['get, post, patch'];
     middlewares = [Auth.authenticate()];
     searchFileds = {
         paciente: {
@@ -26,10 +27,51 @@ export const post = async (req, res) => {
     const status = resp?.status || resp?.errors || 200;
     res.status(status).json(resp);
 };
+
 export const get = async (req, res) => {
     const result = await buscarRecetasInsumos(req);
     res.json(result);
 };
+
+export const getConFiltros = async (req, res) => {
+    const result = await buscarRecetasInsumosConFiltros(req);
+    res.json(result);
+};
+
+export const patch = async (req, res) => {
+    const operacion = req.body.op ? req.body.op.toLowerCase() : '';
+    let result, status;
+    const { recetaId, recetas, dataDispensa } = req.body;
+    const app = req.user.app?.nombre ? req.user.app.nombre.toLowerCase() : '';
+    if ((!recetaId && !recetas)) {
+        const error = new ParamsIncorrect();
+        res.status(error.status).json(error);
+    } else {
+        switch (operacion) {
+            case 'suspender':
+                result = await suspender(recetaId, req);
+                break;
+            case 'dispensar':
+            case 'dispensa-parcial':
+                result = await setEstadoDispensa(req, operacion, app);
+                break;
+            case 'sin-dispensar':
+                result = await actualizarAppNotificada(recetaId, app, req);
+                break;
+            case 'cancelar-dispensa':
+                result = await cancelarDispensa(recetaId, dataDispensa, app, req);
+                break;
+            default:
+                const error = new ParamsIncorrect();
+                status = res.status(error.status).json(error);
+        }
+        if (result) {
+            status = result?.status || 200;
+            res.status(status).json(result);
+        }
+    }
+};
+
 export const RecetaInsumoCtr = new RecetaInsumoResource({});
 export const RecetaInsumoRouter = RecetaInsumoCtr.makeRoutes();
 
@@ -45,4 +87,7 @@ const authorizeByToken = async (req: Request, res: Response, next) =>
 
 RecetaInsumoRouter.use(Auth.authenticate());
 RecetaInsumoRouter.get('/recetasInsumos', authorizeByToken, asyncHandler(get));
+RecetaInsumoRouter.get('/recetasInsumos/filtros', authorizeByToken, asyncHandler(getConFiltros));
 RecetaInsumoRouter.post('/recetasInsumos', authorizeByToken, asyncHandler(post));
+RecetaInsumoRouter.patch('/recetasInsumos', authorizeByToken, asyncHandler(patch));
+

--- a/modules/recetas/recetasInsumos/receta-insumo.schema.ts
+++ b/modules/recetas/recetasInsumos/receta-insumo.schema.ts
@@ -2,6 +2,7 @@ import { AuditPlugin } from '@andes/mongoose-plugin-audit';
 import * as mongoose from 'mongoose';
 import { ProfesionalSubSchema } from '../../../core/tm/schemas/profesional';
 import { PacienteSubSchema } from '../../../core-v2/mpi/paciente/paciente.schema';
+import { generarIdDesdeFecha } from '../recetasController';
 const insumoSubSchema = new mongoose.Schema({
     id: String,
     nombre: String,
@@ -62,7 +63,7 @@ const estadoDispensaSchema = new mongoose.Schema({
 const estadosSchema = new mongoose.Schema({
     tipo: {
         type: String,
-        enum: ['pendiente', 'vigente', 'finalizada', 'vencida', 'suspendida', 'rechazada'],
+        enum: ['pendiente', 'vigente', 'finalizada', 'vencida', 'suspendida', 'rechazada', 'eliminada'],
         required: true,
         default: 'vigente'
     },
@@ -90,8 +91,14 @@ const estadosSchema = new mongoose.Schema({
     }
 });
 
+estadosSchema.plugin(AuditPlugin);
+
 
 export const recetaInsumoSchema = new mongoose.Schema({
+    idReceta: {
+        type: String,
+        required: false
+    },
     organizacion: {
         id: mongoose.SchemaTypes.ObjectId,
         nombre: String
@@ -156,6 +163,13 @@ recetaInsumoSchema.pre('save', function (next) {
     }
 
     next();
+});
+
+recetaInsumoSchema.post('save', async (prescription: any) => {
+    if (!prescription.idReceta) {
+        const id = generarIdDesdeFecha(prescription.createdAt);
+        await mongoose.model('recetasInsumo').updateOne({ _id: prescription._id }, { $set: { idReceta: id } });
+    }
 });
 
 recetaInsumoSchema.plugin(AuditPlugin);

--- a/modules/recetas/recetasInsumos/recetaInsumosController.ts
+++ b/modules/recetas/recetasInsumos/recetaInsumosController.ts
@@ -3,19 +3,22 @@ import { Types } from 'mongoose';
 import { Auth } from '../../../auth/auth.class';
 import { RecetaInsumo } from './receta-insumo.schema';
 import { createLog, informarLog, updateLog } from '../recetaLogs';
-import { ParamsIncorrect, RecetaNotFound } from '../recetas.error';
+import { ParamsIncorrect, RecetaNotFound, RecetaNotEdit } from '../recetas.error';
 import { Paciente } from '../../../core-v2/mpi/paciente/paciente.schema';
 import { Profesional } from '../../../core/tm/schemas/profesional';
-import { getProfesionActualizada } from '../recetasController';
+import { getProfesionActualizada, generarIdDesdeFecha } from '../recetasController';
+import { getReceta } from '../services/receta';
 
 export async function buscarRecetasInsumos(req) {
     const options: any = {};
     const params = req.params.id ? req.params : req.query;
+    const fechaVencimiento = moment().subtract(30, 'days').startOf('day').toDate();
     const pacienteId = params.pacienteId || null;
     const documento = params.documento || null;
     const sexo = params.sexo || null;
+    const user = req.user || {};
     try {
-        if ((!pacienteId && (!documento || !sexo)) || (pacienteId && !Types.ObjectId.isValid(pacienteId))) {
+        if (!params.id && !params.idRegistro && ((!pacienteId && (!documento || !sexo)) || (pacienteId && !Types.ObjectId.isValid(pacienteId)))) {
             throw new ParamsIncorrect();
         }
         const paramMap = {
@@ -23,8 +26,8 @@ export async function buscarRecetasInsumos(req) {
             pacienteId: 'paciente.id',
             documento: 'paciente.documento',
             sexo: 'paciente.sexo',
-            estado: 'estadoActual.tipo',
-            tipo: 'insumo.tipo'
+            tipo: 'insumo.tipo',
+            idRegistro: 'idRegistro'
         };
         Object.keys(paramMap).forEach(key => {
             if (params[key]) {
@@ -33,21 +36,58 @@ export async function buscarRecetasInsumos(req) {
         });
 
         if (params.estadoDispensa) {
-            const estadoDispensaArray = params.estadoDispensa.split(',');
+            const estadoDispensaArray = params.estadoDispensa.replace(/ /g, '').split(',');
             options['estadoDispensaActual.tipo'] = { $in: estadoDispensaArray };
-        } else {
-            options['estadoDispensaActual.tipo'] = 'sin-dispensa';
         }
 
-        if (params.fechaInicio || params.fechaFin) {
-            const fechaInicio = params.fechaInicio ? moment(params.fechaInicio).startOf('day').toDate() : moment().subtract(1, 'years').startOf('day').toDate();
-            const fechaFin = params.fechaFin ? moment(params.fechaFin).endOf('day').toDate() : moment().endOf('day').toDate();
-            options['fechaRegistro'] = { $gte: fechaInicio, $lte: fechaFin };
+        const estadoArray = params.estado ? params.estado.replace(/ /g, '').split(',') : [];
+        const fechaFin = params.fechaFin ? moment(params.fechaFin).endOf('day').toDate() : moment().endOf('day').toDate();
+        const fechaInicio = params.fechaInicio ? moment(params.fechaInicio).startOf('day').toDate() : moment(fechaFin).subtract(1, 'years').startOf('day').toDate();
+
+        if (estadoArray.length) {
+            const optPendientes = {};
+            const optVigentes = {};
+            const optOtros = {};
+            // Para recetas pendientes sin filtro de fechas, limitar a próximos 10 días
+            const includePendiente = estadoArray.includes('pendiente');
+            if (includePendiente) {
+                optPendientes['fechaRegistro'] = {
+                    $gte: fechaInicio,
+                    $lte: params.fechaFin ? fechaFin : moment().add(10, 'days').endOf('day').toDate()
+                };
+                optPendientes['estadoActual.tipo'] = 'pendiente';
+            }
+            // Para recetas vigentes sin filtro de fechas, limitar a 30 días atrás
+            const includeVigente = estadoArray.includes('vigente');
+            if (includeVigente) {
+                const fInicio = params.fechaInicio ? fechaInicio : fechaVencimiento;
+                optVigentes['fechaRegistro'] = params.fechaFin ? { $gte: fInicio, $lte: fechaFin } : { $gte: fInicio };
+                optVigentes['estadoActual.tipo'] = 'vigente';
+            }
+            const includeOtros = estadoArray.filter(e => e !== 'pendiente' && e !== 'vigente');
+            if (includeOtros.length) {
+                optOtros['fechaRegistro'] = { $gte: fechaInicio, $lte: fechaFin };
+                optOtros['estadoActual.tipo'] = { $in: includeOtros };
+            }
+            options['$or'] = [optPendientes, optVigentes, optOtros].filter(o => o.hasOwnProperty('estadoActual.tipo'));
+        } else {
+            options['estadoActual.tipo'] = { $nin: ['eliminada'] };
+            if (user.type === 'app-token') {
+                options['fechaRegistro'] = { $gte: fechaInicio, $lte: fechaFin };
+            }
         }
+
         if (Object.keys(options).length === 0) {
             throw new ParamsIncorrect();
         }
-        const recetasInsumos: any = await RecetaInsumo.find(options);
+
+        let recetasInsumos: any = await RecetaInsumo.find(options);
+
+        if (user.type === 'app-token') {
+            const sistema = user.app.nombre.toLowerCase();
+            recetasInsumos = sistema ? await registrarAppNotificadas(req, recetasInsumos, sistema) : [];
+        }
+
         return recetasInsumos;
     } catch (err) {
         await informarLog.error('buscarRecetasInsumos', { params, options }, err, req);
@@ -248,27 +288,406 @@ export async function suspender(recetaInsumoId, req) {
         if (!recetaInsumo) {
             throw new RecetaNotFound();
         }
-        const recetasASuspender = await RecetaInsumo.find({
-            'insumo.concepto.conceptId': recetaInsumo.insumo.concepto.conceptId,
-            idRegistro: recetaInsumo.idRegistro
-        });
-        const promises = recetasASuspender.map(async (receta: any) => {
-            if ((receta.estadoActual.tipo === 'vigente') || (receta.estadoDispensaActual.tipo !== 'dispensa-parcial' && receta.estadoActual.tipo === 'pendiente')) {
-                receta.estados.push({
-                    tipo: 'suspendida',
-                    motivo,
-                    observacion,
-                    profesional,
-                    fecha: new Date()
-                });
-                Auth.audit(receta, req);
-                await receta.save();
+        const query: any = {
+            idRegistro: recetaInsumo.idRegistro,
+            'estadoActual.tipo': { $nin: ['vencida', 'finalizada'] }
+        };
+        if (recetaInsumo.insumo?.concepto?.conceptId) {
+            query['insumo.concepto.conceptId'] = recetaInsumo.insumo.concepto.conceptId;
+        } else if (recetaInsumo.insumo?.id) {
+            query['insumo.id'] = recetaInsumo.insumo.id;
+        } else if (recetaInsumo.insumo?.nombre) {
+            query['insumo.nombre'] = recetaInsumo.insumo.nombre;
+        }
+
+        const recetasASuspender = await RecetaInsumo.find(query).sort({ fechaRegistro: -1 });
+
+        if (recetasASuspender.length) {
+            const recetasSuspender = recetasASuspender.filter((r: any) => (r.estadoActual.tipo === 'vigente') || (r.estadoDispensaActual?.tipo === 'dispensa-parcial' && r.estadoActual.tipo === 'pendiente'));
+            const recetasEliminar = recetasASuspender.filter((r: any) => (!r.estadoDispensaActual || r.estadoDispensaActual?.tipo === 'sin-dispensa') && r.estadoActual.tipo === 'pendiente');
+            if (recetasSuspender.length === 0 && recetasEliminar.length !== 0) {
+                // en el tratamiento prolongado, al menos una receta debe quedar en estado suspendido
+                const recetaSusp = recetasEliminar.pop();
+                recetasSuspender.push(recetaSusp);
             }
-        });
-        await Promise.all(promises);
-        return { success: true };
+            const recSusp = await Promise.all(await recetasInsumoUpdate(recetasSuspender, 'suspendida', motivo, observacion, profesional, req));
+
+            const rec = recSusp.concat(await Promise.all(await recetasInsumoUpdate(recetasEliminar, 'eliminada', motivo, observacion, profesional, req)));
+
+            return rec;
+        }
+        return recetasASuspender;
     } catch (error) {
         await updateLog.error('suspender', { motivo, observacion, profesional, recetaInsumoId }, error);
         return error;
+    }
+}
+
+async function recetasInsumoUpdate(recetas, estado, motivo, observacion, profesional, req) {
+    return recetas.map(async (receta: any) => {
+        receta.estados.push({
+            tipo: estado,
+            motivo,
+            observacion,
+            profesional,
+        });
+        Auth.audit(receta, req);
+        return await receta.save();
+    });
+}
+
+export async function setEstadoDispensa(req, operacion, app) {
+    const { recetaId } = req.body;
+    const sistema = app || '';
+    const dataDispensa = req.body.dispensa;
+    try {
+        if (!recetaId && sistema) {
+            throw new ParamsIncorrect();
+        }
+
+        let recetaInsumo: any = await RecetaInsumo.findById(recetaId);
+        if (!recetaInsumo) {
+            throw new RecetaNotFound();
+        }
+
+        recetaInsumo = await dispensar(recetaInsumo, operacion, dataDispensa, sistema);
+
+        Auth.audit(recetaInsumo, req);
+        return await recetaInsumo.save();
+    } catch (error) {
+        await updateLog.error('setEstadoDispensaInsumo', { operacion, sistema, recetaId, dataDispensa }, error);
+        return error;
+    }
+}
+
+export async function dispensar(recetaInsumo, operacion, dataDispensa, sistema) {
+    const operacionMap = {
+        dispensar: 'dispensada',
+        'dispensa-parcial': 'dispensa-parcial'
+    };
+
+    const tipoDispensa = operacionMap[operacion] || null;
+    const idDispensaApp = dataDispensa.id;
+    if (!tipoDispensa || !dataDispensa || !idDispensaApp) {
+        throw new ParamsIncorrect();
+    }
+    // controlar que la dispensa no exista ya cargada en la receta
+    const dispensaExistente = recetaInsumo.dispensa.find(d => d.idDispensaApp === idDispensaApp);
+    if (!dispensaExistente) {
+        const dispensa: any = { idDispensaApp };
+        const tipo = (operacion === 'dispensar') ? 'finalizada' : recetaInsumo.estadoActual.tipo;
+        const estadoReceta = { tipo };
+        dispensa.fecha = dataDispensa.fecha ? moment(dataDispensa.fecha).toDate() : moment().toDate();
+        let insumos = [];
+        if (dataDispensa?.insumos?.length) {
+            insumos = dataDispensa.insumos.map(ins => {
+                const insumo: any = {};
+                if (ins.insumo) {
+                    insumo.insumo = ins.insumo || {};
+                    insumo.descripcion = (ins.insumo.nombre || '') + (ins.cantidadEnvases || '');
+                }
+                insumo.unidades = ins.unidades || null;
+                insumo.cantidad = ins.cantidad || null;
+                insumo.cantidadEnvases = ins.cantidadEnvases || null;
+                return insumo;
+            });
+            dispensa.insumos = insumos;
+        }
+        dispensa.organizacion = dataDispensa.organizacion || null;
+        recetaInsumo.dispensa.push(dispensa);
+        recetaInsumo.estados.push(estadoReceta);
+
+        recetaInsumo.estadosDispensa.push({
+            tipo: tipoDispensa,
+            idDispensaApp,
+            fecha: dispensa.fecha,
+            sistema
+        });
+    }
+    return recetaInsumo;
+}
+
+export async function actualizarAppNotificada(idReceta, sistema, req) {
+    try {
+        if (idReceta && Types.ObjectId.isValid(idReceta)) {
+            const recetaInsumo: any = await RecetaInsumo.findById(idReceta);
+            if (!recetaInsumo) {
+                throw new RecetaNotFound();
+            }
+            const estadoActual = recetaInsumo.estadoActual.tipo;
+            const estadoDispensa = recetaInsumo.estadoDispensaActual.tipo;
+            if (estadoActual === 'vigente' && estadoDispensa === 'sin-dispensa') {
+                const app = recetaInsumo.appNotificada.find(a => a.app === sistema);
+                if (app) {
+                    recetaInsumo.appNotificada = recetaInsumo.appNotificada.filter(a => a.app !== sistema);
+                    Auth.audit(recetaInsumo, req);
+                    await recetaInsumo.save();
+                    await updateLog.info('sin-dispensar', { sistema, idReceta, recetaInsumo });
+                    return recetaInsumo;
+                } else {
+                    throw new RecetaNotEdit(`${sistema.toUpperCase()} no puede marcar sin-dispensa una receta no consultada`);
+                }
+            } else {
+                const motivo = {
+                    'sin-dispensa': '',
+                    'dispensa-parcial': ' con dispensa parcial',
+                    dispensada: ' dispensada',
+                };
+                throw new RecetaNotEdit(`No se puede marcar sin-dispensar una receta ${estadoActual + motivo[estadoDispensa]}`);
+            }
+        }
+    } catch (error) {
+        await updateLog.error('actualizarAppNotificada', { sistema, idReceta }, error);
+        return error;
+    }
+}
+
+export async function cancelarDispensa(idReceta, dataDispensa, sistema, req) {
+    try {
+        const idDispensa = dataDispensa.idDispensa;
+        const motivo = dataDispensa.motivo;
+        const organizacion = dataDispensa.organizacion;
+        const idValido = idReceta && Types.ObjectId.isValid(idReceta);
+        if (idValido && idDispensa) {
+            const recetaInsumo: any = await RecetaInsumo.findById(idReceta);
+            if (!recetaInsumo) {
+                throw new RecetaNotFound();
+            }
+            const estadoActual = recetaInsumo.estadoActual.tipo;
+            const estadoDispensa = recetaInsumo.estadoDispensaActual.tipo;
+            if (estadoDispensa !== 'sin-dispensa') {
+                const tipo = (recetaInsumo.estadoActual.tipo === 'finalizada') ? await calcularEstadoReceta(recetaInsumo) : recetaInsumo.estadoActual.tipo;
+                const estadoReceta = { tipo };
+                recetaInsumo.estados.push(estadoReceta);
+
+                recetaInsumo.dispensa = recetaInsumo.dispensa.filter(disp => disp.idDispensaApp !== idDispensa);
+                const tipoDispensa = (recetaInsumo.dispensa.length) ? 'dispensa-parcial' : 'sin-dispensa';
+                recetaInsumo.estadosDispensa.push({
+                    tipo: tipoDispensa,
+                    fecha: new Date(),
+                    sistema,
+                    cancelada: {
+                        idDispensaApp: idDispensa,
+                        motivo,
+                        organizacion
+                    }
+                });
+
+                recetaInsumo.appNotificada = recetaInsumo.appNotificada.filter(a => a.app !== sistema);
+                Auth.audit(recetaInsumo, req);
+                await recetaInsumo.save();
+                await updateLog.info('cancelarDispensa', { sistema, idReceta, dataDispensa });
+                return recetaInsumo;
+            } else {
+                throw new RecetaNotEdit(`No se puede cancelar dispensa de una receta ${estadoActual} no dispensada`);
+            }
+        } else {
+            throw new ParamsIncorrect();
+        }
+    } catch (error) {
+        await updateLog.error('cancelarDispensa', { sistema, idReceta, dataDispensa }, error);
+        return error;
+    }
+}
+
+export async function calcularEstadoReceta(recetaInsumo) {
+    const today = moment();
+    const fechaVencimiento = moment(recetaInsumo.fechaRegistro).add(30, 'days');
+    if (today.isBefore(fechaVencimiento)) {
+        return 'vigente';
+    } else {
+        return 'vencida';
+    }
+}
+
+export async function consultarEstadoInsumo(recetaInsumo, sistema) {
+    try {
+        const pacienteId = recetaInsumo.paciente.id.toString();
+        const recetaDisp = await getReceta(Types.ObjectId(recetaInsumo.id), Types.ObjectId(pacienteId), sistema);
+
+        if (!recetaDisp) {
+            return {
+                success: false,
+                recetaDisp: null
+            };
+        }
+
+        const tipo = recetaDisp.tipoDispensaActual;
+        const dispensada = ['dispensada', 'dispensa-parcial'].includes(tipo);
+
+        return {
+            success: true,
+            recetaDisp,
+            tipo,
+            dispensada
+        };
+    } catch (error) {
+        await informarLog.error('consultarEstadoInsumo', { recetaId: recetaInsumo.id, sistema }, error);
+        return {
+            success: false,
+            error
+        };
+    }
+}
+
+async function registrarAppNotificadas(req, recetas, sistema) {
+    let recetasPaciente = [];
+    recetasPaciente = recetas.map(async receta => {
+        let incluirReceta = true;
+        const appN = { app: sistema, fecha: moment().toDate() };
+        const arrayApps = receta.appNotificada || [];
+        if (arrayApps.length) {
+            let indiceApp = arrayApps.findIndex(a => a.app === sistema);
+            if (indiceApp !== -1) {
+                arrayApps[indiceApp].fecha = moment().toDate();
+            } else {
+                indiceApp = arrayApps.findIndex(a => a.app !== sistema);
+                const sistema2 = arrayApps[indiceApp].app;
+                const resultado = await consultarEstadoInsumo(receta, sistema2);
+
+                if (resultado.success) {
+                    const { recetaDisp, tipo, dispensada } = resultado;
+
+                    if (dispensada) {
+                        recetaDisp.dispensas.forEach(async d => {
+                            const dispensaInsumo = {
+                                ...d.dispensa,
+                                insumos: d.dispensa.insumos || d.dispensa.medicamentos
+                            };
+                            receta = d.estado ? await dispensar(receta, d.estado, dispensaInsumo, sistema2) : receta;
+                        });
+                        incluirReceta = false;
+                    } else {
+                        if (tipo === 'sin-dispensa') {
+                            receta.appNotificada = arrayApps.filter(a => a.app !== sistema2);
+                            receta.appNotificada.push(appN);
+                        } else {
+                            receta.appNotificada[indiceApp].fecha = moment().toDate();
+                            incluirReceta = false;
+                        }
+                    }
+                } else {
+                    incluirReceta = false;
+                }
+            }
+        } else {
+            receta.appNotificada.push(appN);
+            incluirReceta = true;
+        }
+        Auth.audit(receta, req);
+        await receta.save();
+        return incluirReceta ? receta : null;
+    });
+    const recetasUpdated = await Promise.all(recetasPaciente);
+    return recetasUpdated.filter(r => r !== null);
+}
+
+/**
+ * Busca recetas de insumos filtrando por rango de fechas y estado.
+ * Incluye estados de receta y de dispensa simultáneamente.
+ */
+export async function buscarRecetasInsumosConFiltros(req) {
+    try {
+        const { fechaInicio, fechaFin, estado, documento, sexo } = req.query;
+        const filter: any = {};
+        const statusVal = req.query.status;
+        const estadoVal = estado;
+        let estadoParam = null;
+
+        if (estadoVal && statusVal) {
+            estadoParam = `${estadoVal},${statusVal}`;
+        } else {
+            estadoParam = estadoVal ?? statusVal;
+        }
+        if (!estadoParam || String(estadoParam).trim() === '') {
+            estadoParam = 'vigente';
+        }
+
+        // Validación mínima: al menos un filtro
+        if (!documento && !sexo && !estadoParam) {
+            throw new ParamsIncorrect();
+        }
+
+        // Filtro por rango de fechas sobre fechaRegistro
+        if (fechaInicio || fechaFin) {
+            filter['fechaRegistro'] = {};
+            if (fechaInicio) {
+                filter['fechaRegistro'].$gte = moment(fechaInicio, 'DD-MM-YYYY').startOf('day').toDate();
+            }
+            if (fechaFin) {
+                filter['fechaRegistro'].$lte = moment(fechaFin, 'DD-MM-YYYY').endOf('day').toDate();
+            }
+        } else {
+            // Default: último mes hasta hoy si no se especifican fechas
+            filter['fechaRegistro'] = {
+                $gte: moment().subtract(1, 'months').startOf('day').toDate(),
+                $lte: moment().endOf('day').toDate()
+            };
+        }
+
+        // Filtro por estado aplicado tanto a receta como a dispensa
+        if (estadoParam) {
+            const estadosRaw = String(estadoParam).replace(/ /g, '').split(',').filter(Boolean);
+            const incluyeTodas = estadosRaw.some(e => e.toLowerCase() === 'todas');
+            // Si llega "todas" (solo o incluido), no aplicar filtro de estado
+            if (!incluyeTodas) {
+                const estados = estadosRaw;
+                if (estados.length) {
+                    const or: any[] = [];
+                    if (estados.length === 1) {
+                        const val = estados[0];
+                        or.push({ 'estadoActual.tipo': val });
+                        or.push({ 'estadoDispensaActual.tipo': val });
+                    } else {
+                        estados.forEach(val => {
+                            or.push({ 'estadoActual.tipo': val });
+                            or.push({ 'estadoDispensaActual.tipo': val });
+                        });
+                    }
+                    filter['$or'] = or;
+                }
+            } else {
+                // Forzar que se tome cualquier estadoActual.tipo
+                filter['estadoActual.tipo'] = { $exists: true };
+            }
+        }
+
+        // Filtros por datos del paciente
+        if (documento) {
+            filter['paciente.documento'] = documento;
+        }
+        if (sexo) {
+            filter['paciente.sexo'] = sexo;
+        }
+
+        let recetasInsumos: any = await RecetaInsumo.find(filter);
+
+        if (!recetasInsumos.length) {
+            return [];
+        }
+
+        // Generar idReceta para recetas que no lo tengan
+        const recetasActualizadas = [];
+        for (const receta of recetasInsumos) {
+            if (!receta.idReceta) {
+                receta.idReceta = generarIdDesdeFecha(receta.createdAt || new Date());
+                Auth.audit(receta, req);
+                await receta.save();
+            }
+            recetasActualizadas.push(receta);
+        }
+        recetasInsumos = recetasActualizadas;
+
+        const user = req.user;
+        if (user?.type === 'app-token') {
+            // si es un usuario de app y no tiene nombre de sistema asignado, no se envia recetas
+            const sistema = user.app?.nombre ? user.app.nombre.toLowerCase() : '';
+            recetasInsumos = sistema ? await registrarAppNotificadas(req, recetasInsumos, sistema) : [];
+        }
+
+        return recetasInsumos;
+    } catch (err) {
+        await informarLog.error('buscarRecetasInsumosConFiltros', { query: req.query }, err, req);
+        return err;
     }
 }


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
<!-- URL de la User Story, referencia al issue (#1111) o breve descripcion del requerimiento -->
https://proyectos.andes.gob.ar/browse/REC-262
### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Nuevas Operaciones y Endpoint PATCH para Insumos
Archivos: receta-insumo.routes.ts y recetaInsumosController.ts

Habilitación de PATCH: Se habilitó el método PATCH para el recurso /recetasInsumos en el enrutador.
suspender: Cambia el estado de una receta de insumo a suspendida.
dispensar / dispensa-parcial: Registra una dispensa (total o parcial) guardando los detalles de los insumos entregados, cantidades, fechas, organización y el ID externo de la transacción.
sin-dispensar (actualizarAppNotificada): Permite que una aplicación externa libere/desmarque una receta de insumo que fue consultada pero no dispensada.
cancelar-dispensa: Revierte una dispensa registrada previamente buscando por su ID de dispensa (idDispensaApp) y guardando los motivos y la organización que realizó la cancelación.

2. Optimización y Flexibilización en la Búsqueda de Recetas

Búsquedas por ID o ID de Registro sin requerir Paciente:
Ahora, si se busca por un id específico de receta o por idRegistro (ID de tratamiento prolongado o agrupador), no es obligatorio enviar datos de identificación del paciente (pacienteId, documento y sexo).
Se agregó el mapeo del parámetro idRegistro para permitir filtrar y agrupar recetas vinculadas a un mismo tratamiento.
Resolución de conflictos al filtrar por Estado:
Medicamentos: Se eliminó la lógica restrictiva que forzaba a establecer estadoActual.tipo = null cuando no se proporcionaba un estadoDispensa en la consulta. Esto permite filtrar libremente por el estado de la receta.
Insumos: Se eliminó el filtro por defecto 'sin-dispensa' cuando no se especificaba el estado de la dispensa.

3. Filtros Avanzados y Sincronización con Apps Externas en Insumos
Filtros Temporales Inteligentes: Se implementó una lógica de rangos de fechas dinámicos según el estado consultado (pendiente limita a próximos 10 días si no se especifica fin, vigente limita a los últimos 30 días atrás).
Control de Notificaciones e Integración (appNotificada):
Al realizar consultas con un token de aplicación (user.type === 'app-token'), el sistema ahora registra automáticamente la consulta (registrarAppNotificadas).
Si la receta de insumo ya registra una dispensa activa en otro sistema externo conectado, el controlador sincroniza y replica ese estado localmente antes de devolver el resultado.

4. Se agrega  Endpoint: GET /api/modules/recetasInsumos/filtros analogo a receta de medicamentos
5. Se agrega idReceta
6. Se agrega audit en estados de receta de insumos (createdAt)


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->
<img width="675" height="593" alt="image" src="https://github.com/user-attachments/assets/fd7107fe-f5c8-4215-91ab-17adbf5cf0f9" />


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
