### PR TITLE
fix: buscar laboratorios de RN probando todos los referentes (padre/m…

### DIFF
--- a/modules/rup/laboratorios.controller.ts
+++ b/modules/rup/laboratorios.controller.ts
@@ -93,8 +93,55 @@ export async function searchByDocumento(pacienteId, fechaDesde?, fechaHasta?) {
             } else {
                 if (paciente.edad <= 5 && paciente.relaciones?.length) { // recien nacido (aún sin dni)
                     estado = 'RN';
-                    const tutorProgenitor = paciente.relaciones.find(rel => rel.relacion.nombre === 'progenitor/a') || paciente.relaciones.find(rel => rel.relacion.nombre === 'tutor');
-                    documento = tutorProgenitor?.documento || tutorProgenitor?.numeroIdentificacion || null;
+
+                    // El bebé sin DNI queda asociado, del lado del laboratorio, a UN
+                    // solo referente (padre, madre o tutor/a) — nunca a varios a la
+                    // vez. No sabemos de antemano cuál de sus relaciones es la
+                    // asociada, así que se prueba cada una hasta encontrar la que
+                    // tiene laboratorios cargados.
+                    const referentes = paciente.relaciones.filter(
+                        rel => rel.relacion.nombre === 'progenitor/a' || rel.relacion.nombre === 'tutor'
+                    );
+
+                    if (!referentes.length) {
+                        return [];
+                    }
+
+                    const documentosReferentes = referentes
+                        .map(rel => rel.documento || rel.numeroIdentificacion)
+                        .filter(doc => !!doc);
+
+                    // Saco duplicados (ej: si por error padre y madre comparten el
+                    // mismo documento cargado, no se hace la misma consulta dos veces)
+                    const documentosUnicos = Array.from(new Set(documentosReferentes));
+
+                    if (!documentosUnicos.length) {
+                        return [];
+                    }
+
+                    const dataSearchBase = {
+                        estado,
+                        fechaNac: moment(paciente.fechaNacimiento).utc().format('YYYYMMDD'),
+                        apellido: paciente.apellido,
+                        fechaDesde,
+                        fechaHasta
+                    };
+
+                    for (const dni of documentosUnicos) {
+                        dataSearch = { ...dataSearchBase, dni };
+                        try {
+                            const resultado = await this.search(dataSearch);
+                            if (Array.isArray(resultado) && resultado.length > 0) {
+                                return resultado;
+                            }
+                        } catch (err) {
+                            // Este referente no tiene laboratorios (o falló la consulta
+                            // puntual): se sigue probando con el resto de los referentes.
+                        }
+                    }
+
+                    // Ningún referente tenía laboratorios asociados
+                    return [];
                 }
             }
             if (!estado || !documento) {


### PR DESCRIPTION
MPI-483 
https://proyectos.andes.gob.ar/secure/RapidBoard.jspa?rapidView=26&view=planning&selectedIssue=MPI-483&quickFilter=153&issueLimit=100

-->
### Requerimiento
Cuando se consulta por los laboratorios de un recién nacido (aún sin documento de identidad), 
se utilizaba únicamente el DNI de un solo referente (padre, madre o tutor/a) para buscar 
sus análisis. Esto dejaba sin cubrir los casos en que el laboratorio del bebé está cargado 
con el documento de un referente distinto al elegido por el código.

### Funcionalidad desarrollada
1. Se identifican todos los referentes del bebé (padre, madre, tutor/a) con documento válido, en vez de tomar solo el primero.
2. Se consulta al servicio de laboratorio probando cada referente hasta encontrar el que tiene laboratorios asociados (un bebé sin DNI solo puede estar asociado a un único referente del lado del laboratorio).
3. Si un referente no tiene resultados o falla la consulta, se continúa probando con el siguiente sin cortar el proceso.

### UserStories llegó a completarse
- [ ] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No
